### PR TITLE
Add database bootstrap tooling and schema assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,74 @@
+# Database Administration Assets
+
+This directory contains the assets required to provision and seed the
+clinical trial administration database.
+
+## Contents
+
+- `sql/` — schema definition and seed data scripts executed in order by the
+  bootstrapper:
+  1. `vocabulary_tables.sql` — controlled vocabularies (countries,
+     recruitment statuses, etc.).
+  2. `clinical_trial_tables.sql` — core trial entities and relationships.
+  3. `supporting_objects.sql` — triggers, helper functions, and stored
+     procedures supporting the application.
+  4. `vocabulary_seed.sql` — initial lookup data for the vocabulary tables.
+- `bootstrap.py` — Python script that connects to PostgreSQL, executes the
+  schema, and loads the seed data.
+
+## Prerequisites
+
+- Python 3.9+
+- [`psycopg2`](https://www.psycopg.org/docs/install.html) (install via
+  `pip install psycopg2-binary` if the native build prerequisites are not
+  available)
+- Access to a PostgreSQL database with privileges to create tables,
+  functions, triggers, and insert data.
+
+## Configuration
+
+The bootstrap script accepts a PostgreSQL connection in one of two ways:
+
+1. Provide a full `DATABASE_URL` DSN (e.g. `postgresql://user:pass@localhost:5432/ctms`).
+2. Or set the component environment variables:
+   - `DB_HOST` (default: `localhost`)
+   - `DB_PORT` (default: `5432`)
+   - `DB_NAME` (**required**)
+   - `DB_USER` (**required**)
+   - `DB_PASSWORD` (optional)
+
+## Running the Bootstrap Script
+
+1. Install dependencies (ideally within a virtual environment):
+
+   ```bash
+   pip install psycopg2-binary
+   ```
+
+2. Export the connection details for your target database:
+
+   ```bash
+   export DB_HOST=localhost
+   export DB_PORT=5432
+   export DB_NAME=ctms
+   export DB_USER=postgres
+   export DB_PASSWORD=secret
+   ```
+
+3. Execute the bootstrapper using the module invocation so the relative paths
+   resolve correctly:
+
+   ```bash
+   python -m database.bootstrap
+   ```
+
+   Alternatively, specify a DSN directly:
+
+   ```bash
+   DATABASE_URL="postgresql://postgres:secret@localhost:5432/ctms" \
+     python -m database.bootstrap
+   ```
+
+On success the script prints progress for each SQL file and exits after the
+schema and seed data have been applied.
+

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,2 @@
+"""Database bootstrap package for clinical trial administration assets."""
+

--- a/database/bootstrap.py
+++ b/database/bootstrap.py
@@ -1,0 +1,108 @@
+"""Bootstrap clinical trial administration database schema and seed data.
+
+The script expects access to a PostgreSQL database via either:
+
+* ``DATABASE_URL``: a libpq connection string / DSN (e.g. ``postgresql://user:pass@localhost:5432/ctms``)
+* or the component environment variables ``DB_HOST`` (default ``localhost``), ``DB_PORT`` (default ``5432``),
+  ``DB_NAME`` (required), ``DB_USER`` (required), and optional ``DB_PASSWORD``.
+
+Example usage::
+
+    export DB_HOST=localhost
+    export DB_PORT=5432
+    export DB_NAME=ctms
+    export DB_USER=postgres
+    export DB_PASSWORD=secret
+    python -m database.bootstrap
+
+The script executes all SQL files in ``database/sql`` in a deterministic order and
+wraps the process in a transaction. Seed data is loaded after the schema and
+supporting objects are created.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+import psycopg2
+
+BASE_DIR = Path(__file__).resolve().parent
+SQL_DIR = BASE_DIR / "sql"
+
+SCHEMA_FILES = [
+    "vocabulary_tables.sql",
+    "clinical_trial_tables.sql",
+    "supporting_objects.sql",
+    "vocabulary_seed.sql",
+]
+
+
+def build_dsn() -> str:
+    """Construct a libpq connection string from environment variables."""
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        return database_url
+
+    missing: List[str] = []
+    db_name = os.getenv("DB_NAME")
+    if not db_name:
+        missing.append("DB_NAME")
+    db_user = os.getenv("DB_USER")
+    if not db_user:
+        missing.append("DB_USER")
+
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables for database connection: "
+            + ", ".join(missing)
+        )
+
+    db_host = os.getenv("DB_HOST", "localhost")
+    db_port = os.getenv("DB_PORT", "5432")
+    db_password = os.getenv("DB_PASSWORD")
+
+    dsn_parts = [
+        f"host={db_host}",
+        f"port={db_port}",
+        f"dbname={db_name}",
+        f"user={db_user}",
+    ]
+
+    if db_password:
+        dsn_parts.append(f"password={db_password}")
+
+    return " ".join(dsn_parts)
+
+
+def iter_sql_files(filenames: Iterable[str]) -> Iterable[Path]:
+    for name in filenames:
+        path = SQL_DIR / name
+        if not path.exists():
+            raise FileNotFoundError(f"Expected SQL file missing: {path}")
+        yield path
+
+
+def execute_file(cursor, path: Path) -> None:
+    with path.open("r", encoding="utf-8") as handle:
+        sql = handle.read()
+    print(f"Applying {path.relative_to(BASE_DIR)} ...")
+    cursor.execute(sql)
+
+
+def main() -> None:
+    dsn = build_dsn()
+    print("Connecting to PostgreSQL with DSN:", dsn)
+    with psycopg2.connect(dsn) as connection:
+        connection.autocommit = False
+        with connection.cursor() as cursor:
+            for sql_file in iter_sql_files(SCHEMA_FILES):
+                execute_file(cursor, sql_file)
+        connection.commit()
+    print("Bootstrap completed successfully.")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/database/sql/clinical_trial_tables.sql
+++ b/database/sql/clinical_trial_tables.sql
@@ -1,0 +1,58 @@
+-- Core clinical trial tables that rely on the vocabulary tables.
+
+CREATE TABLE IF NOT EXISTS sponsors (
+    sponsor_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    sponsor_type TEXT,
+    contact_email TEXT
+);
+
+CREATE TABLE IF NOT EXISTS trials (
+    trial_id SERIAL PRIMARY KEY,
+    public_identifier TEXT NOT NULL UNIQUE,
+    official_title TEXT NOT NULL,
+    brief_summary TEXT,
+    recruitment_status_id INTEGER NOT NULL REFERENCES recruitment_statuses(recruitment_status_id),
+    study_phase_id INTEGER REFERENCES study_phases(study_phase_id),
+    primary_completion_date DATE,
+    overall_completion_date DATE,
+    lead_sponsor_id INTEGER REFERENCES sponsors(sponsor_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS trial_countries (
+    trial_country_id SERIAL PRIMARY KEY,
+    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
+    country_id INTEGER NOT NULL REFERENCES countries(country_id),
+    city TEXT,
+    site_name TEXT,
+    UNIQUE (trial_id, country_id, COALESCE(city, ''), COALESCE(site_name, ''))
+);
+
+CREATE TABLE IF NOT EXISTS interventions (
+    intervention_id SERIAL PRIMARY KEY,
+    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
+    intervention_type_id INTEGER NOT NULL REFERENCES intervention_types(intervention_type_id),
+    name TEXT NOT NULL,
+    description TEXT,
+    UNIQUE (trial_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS trial_conditions (
+    trial_condition_id SERIAL PRIMARY KEY,
+    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
+    condition_category_id INTEGER REFERENCES condition_categories(condition_category_id),
+    condition_name TEXT NOT NULL,
+    UNIQUE (trial_id, condition_name)
+);
+
+CREATE TABLE IF NOT EXISTS trial_documents (
+    trial_document_id SERIAL PRIMARY KEY,
+    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
+    document_type TEXT NOT NULL,
+    document_url TEXT NOT NULL,
+    is_confidential BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+

--- a/database/sql/supporting_objects.sql
+++ b/database/sql/supporting_objects.sql
@@ -1,0 +1,102 @@
+-- Supporting database objects: functions, procedures, and triggers
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'trials_set_updated_at'
+    ) THEN
+        CREATE TRIGGER trials_set_updated_at
+        BEFORE UPDATE ON trials
+        FOR EACH ROW
+        EXECUTE FUNCTION set_updated_at();
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_or_create_sponsor(p_name TEXT, p_type TEXT, p_email TEXT)
+RETURNS INTEGER AS $$
+DECLARE
+    v_id INTEGER;
+BEGIN
+    IF p_name IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT sponsor_id INTO v_id
+    FROM sponsors
+    WHERE name = p_name;
+
+    IF v_id IS NULL THEN
+        INSERT INTO sponsors(name, sponsor_type, contact_email)
+        VALUES (p_name, p_type, p_email)
+        RETURNING sponsor_id INTO v_id;
+    END IF;
+
+    RETURN v_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE PROCEDURE create_trial(
+    p_public_identifier TEXT,
+    p_official_title TEXT,
+    p_recruitment_status_code TEXT,
+    p_study_phase_code TEXT DEFAULT NULL,
+    p_brief_summary TEXT DEFAULT NULL,
+    p_lead_sponsor_name TEXT DEFAULT NULL,
+    p_lead_sponsor_type TEXT DEFAULT NULL,
+    p_lead_sponsor_email TEXT DEFAULT NULL
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_recruitment_status_id INTEGER;
+    v_study_phase_id INTEGER;
+    v_lead_sponsor_id INTEGER;
+BEGIN
+    SELECT recruitment_status_id INTO v_recruitment_status_id
+    FROM recruitment_statuses
+    WHERE status_code = p_recruitment_status_code;
+
+    IF v_recruitment_status_id IS NULL THEN
+        RAISE EXCEPTION 'Unknown recruitment status code: %', p_recruitment_status_code;
+    END IF;
+
+    IF p_study_phase_code IS NOT NULL THEN
+        SELECT study_phase_id INTO v_study_phase_id
+        FROM study_phases
+        WHERE phase_code = p_study_phase_code;
+
+        IF v_study_phase_id IS NULL THEN
+            RAISE EXCEPTION 'Unknown study phase code: %', p_study_phase_code;
+        END IF;
+    END IF;
+
+    v_lead_sponsor_id := get_or_create_sponsor(p_lead_sponsor_name, p_lead_sponsor_type, p_lead_sponsor_email);
+
+    INSERT INTO trials (
+        public_identifier,
+        official_title,
+        recruitment_status_id,
+        study_phase_id,
+        brief_summary,
+        lead_sponsor_id
+    )
+    VALUES (
+        p_public_identifier,
+        p_official_title,
+        v_recruitment_status_id,
+        v_study_phase_id,
+        p_brief_summary,
+        v_lead_sponsor_id
+    );
+END;
+$$;
+

--- a/database/sql/vocabulary_seed.sql
+++ b/database/sql/vocabulary_seed.sql
@@ -1,0 +1,42 @@
+-- Seed data for vocabulary tables
+
+INSERT INTO countries (iso_alpha2, iso_alpha3, name) VALUES
+    ('US', 'USA', 'United States'),
+    ('CA', 'CAN', 'Canada'),
+    ('GB', 'GBR', 'United Kingdom'),
+    ('BR', 'BRA', 'Brazil'),
+    ('ZA', 'ZAF', 'South Africa')
+ON CONFLICT (iso_alpha2) DO NOTHING;
+
+INSERT INTO recruitment_statuses (status_code, description) VALUES
+    ('NOT_YET_RECRUITING', 'Trial has been registered but enrollment has not yet begun.'),
+    ('RECRUITING', 'Actively recruiting participants.'),
+    ('ACTIVE_NOT_RECRUITING', 'Active, but not currently recruiting participants.'),
+    ('COMPLETED', 'Study has reached overall completion and data collection has ended.'),
+    ('TERMINATED', 'Study has stopped early and will not start again.')
+ON CONFLICT (status_code) DO NOTHING;
+
+INSERT INTO intervention_types (type_code, description) VALUES
+    ('DRUG', 'Pharmaceutical or biological drug interventions.'),
+    ('DEVICE', 'Medical device interventions.'),
+    ('PROCEDURE', 'Surgical or procedural interventions.'),
+    ('BEHAVIORAL', 'Behavioral, lifestyle, or educational interventions.'),
+    ('DIETARY_SUPPLEMENT', 'Vitamins, minerals, and dietary supplements.')
+ON CONFLICT (type_code) DO NOTHING;
+
+INSERT INTO study_phases (phase_code, description) VALUES
+    ('EARLY_PHASE1', 'Early Phase 1 (formerly Phase 0).'),
+    ('PHASE1', 'Phase 1 safety trials.'),
+    ('PHASE2', 'Phase 2 efficacy and side effects trials.'),
+    ('PHASE3', 'Phase 3 effectiveness trials.'),
+    ('PHASE4', 'Phase 4 post-marketing studies.')
+ON CONFLICT (phase_code) DO NOTHING;
+
+INSERT INTO condition_categories (category_code, name, description) VALUES
+    ('ONCOLOGY', 'Oncology', 'Cancer-related conditions.'),
+    ('CARDIO', 'Cardiology', 'Cardiovascular system disorders.'),
+    ('NEURO', 'Neurology', 'Brain and nervous system conditions.'),
+    ('INFECT', 'Infectious Disease', 'Viral and bacterial infections.'),
+    ('ENDO', 'Endocrinology', 'Hormonal and metabolic disorders.')
+ON CONFLICT (category_code) DO NOTHING;
+

--- a/database/sql/vocabulary_tables.sql
+++ b/database/sql/vocabulary_tables.sql
@@ -1,0 +1,35 @@
+-- Vocabulary tables for clinical trial administration
+-- These tables hold controlled vocabularies referenced by the core schema.
+
+CREATE TABLE IF NOT EXISTS countries (
+    country_id SERIAL PRIMARY KEY,
+    iso_alpha2 CHAR(2) NOT NULL UNIQUE,
+    iso_alpha3 CHAR(3) NOT NULL UNIQUE,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS recruitment_statuses (
+    recruitment_status_id SERIAL PRIMARY KEY,
+    status_code TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS intervention_types (
+    intervention_type_id SERIAL PRIMARY KEY,
+    type_code TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS study_phases (
+    study_phase_id SERIAL PRIMARY KEY,
+    phase_code TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS condition_categories (
+    condition_category_id SERIAL PRIMARY KEY,
+    category_code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    description TEXT
+);
+


### PR DESCRIPTION
## Summary
- add vocabulary, core schema, and supporting SQL assets for the clinical trial database
- seed lookup tables for countries, recruitment statuses, intervention types, study phases, and condition categories
- provide a Python bootstrapper and documentation for running the database setup

## Testing
- python -m compileall database

------
https://chatgpt.com/codex/tasks/task_e_68da9104ed3083278b0d385f1968ac73