### PR TITLE
Use expression index for trial country uniqueness

### DIFF
--- a/database/sql/clinical_trial_tables.sql
+++ b/database/sql/clinical_trial_tables.sql
@@ -26,9 +26,11 @@ CREATE TABLE IF NOT EXISTS trial_countries (
     trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
     country_id INTEGER NOT NULL REFERENCES countries(country_id),
     city TEXT,
-    site_name TEXT,
-    UNIQUE (trial_id, country_id, COALESCE(city, ''), COALESCE(site_name, ''))
+    site_name TEXT
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS trial_countries_unique_idx
+    ON trial_countries (trial_id, country_id, COALESCE(city, ''), COALESCE(site_name, ''));
 
 CREATE TABLE IF NOT EXISTS interventions (
     intervention_id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- remove the in-table unique constraint on trial_countries
- add an expression-based unique index to preserve uniqueness by city and site name

## Testing
- python -m database.bootstrap *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68dab1d4e5b08327a62d8bebb2e5b512