### PR TITLE
Add requirements manifest and clarify Django setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ The project ships with a database router (`backend/backend/dbrouters.py`) that p
 from managing migrations for the `auth` and `contenttypes` applications. This allows the framework
 to read/write the shared tables while leaving their schema under manual control.
 
-After setting the database environment variables, apply the remaining Django core migrations
-(sessions, admin, messages, etc.) normally:
+After setting the database environment variables, install the Python dependencies and apply the
+remaining Django core migrations (sessions, admin, messages, etc.) normally:
 
 ```bash
 cd backend
+pip install -r ../requirements.txt
 python manage.py migrate --noinput
 ```
 

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -10,9 +10,9 @@ def main() -> None:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
+            "Couldn't import Django. Install the backend dependencies with "
+            "`pip install -r ../requirements.txt` from the project root and "
+            "make sure your virtual environment is active."
         ) from exc
     execute_from_command_line(sys.argv)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django>=4.2,<5.0
+psycopg2-binary>=2.9
+PyMySQL>=1.0


### PR DESCRIPTION
## Summary
- add a project-level requirements.txt with Django and database driver dependencies
- document installing requirements.txt before running Django migrations
- update manage.py to suggest installing from requirements.txt when Django is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabe26d68883279f247c1289899219