### PR TITLE
Improve bootstrap idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ individual scripts:
 3. The script applies the schema files in dependency order, deploys the
    procedures declared in `database/stored_procedures/procedures.json`, and
    finally loads the seed data from `database/sql/vocabulary_seed.sql`.
+   Objects whose definitions already match the repository are detected via
+   `pg_catalog` and skipped with a log message so reruns remain idempotent.
 
 ### Key schema components
 

--- a/database/README.md
+++ b/database/README.md
@@ -75,6 +75,22 @@ The bootstrap script accepts a PostgreSQL connection in one of two ways:
 On success the script prints progress for each SQL file and exits after the
 schema and seed data have been applied.
 
+### Idempotent DDL deployment
+
+During execution the bootstrapper now inspects each SQL file and compares the
+`CREATE TABLE`/`VIEW`/`FUNCTION`/`PROCEDURE` statements against the current
+database definitions using `information_schema`/`pg_catalog`. When a stored
+object already matches the checked-in definition the script skips re-applying
+that block and logs the skip so administrators know no changes were required.
+Only differing objects are executed, which keeps reruns safe while still
+catching drift. Files that contain non-DDL statements (such as seed data) are
+always executed.
+
+The stored procedure catalog in `stored_procedures/procedures.json` continues to
+drive function/procedure deployment. Entries flagged with `"updated": false`
+are executed regardless of previous runs so that curated routines can be
+redeployed intentionally.
+
 ## Managing Stored Procedures
 
 Stored procedures and functions live in `database/stored_procedures/` as

--- a/database/bootstrap.py
+++ b/database/bootstrap.py
@@ -23,9 +23,10 @@ supporting objects are created.
 from __future__ import annotations
 
 import os
+import re
 from datetime import date
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional, Tuple
 
 import psycopg2
 
@@ -89,11 +90,242 @@ def iter_sql_files(filenames: Iterable[str]) -> Iterable[Path]:
         yield path
 
 
+CREATE_OBJECT_RE = re.compile(
+    r"^CREATE\s+(OR\s+REPLACE\s+)?"
+    r"(?P<type>TABLE|VIEW|MATERIALIZED\s+VIEW|FUNCTION|PROCEDURE)"
+    r"\s+(IF\s+NOT\s+EXISTS\s+)?(?P<name>[\w\.\"']+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _split_statements(sql: str) -> List[str]:
+    statements: List[str] = []
+    current: List[str] = []
+    in_single = False
+    in_double = False
+    dollar_tag: Optional[str] = None
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if dollar_tag:
+            if sql.startswith(dollar_tag, i):
+                current.append(dollar_tag)
+                i += len(dollar_tag)
+                dollar_tag = None
+                continue
+            current.append(ch)
+            i += 1
+            continue
+
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            current.append(ch)
+            i += 1
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            current.append(ch)
+            i += 1
+            continue
+        if ch == "$" and not in_single and not in_double:
+            end = i + 1
+            while end < len(sql) and (sql[end].isalnum() or sql[end] == "_"):
+                end += 1
+            if end < len(sql) and sql[end] == "$":
+                tag = sql[i : end + 1]
+                dollar_tag = tag
+                current.append(tag)
+                i = end + 1
+                continue
+        if ch == ";" and not in_single and not in_double:
+            statement = "".join(current).strip()
+            if statement:
+                statements.append(statement)
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+
+    tail = "".join(current).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def _normalize_sql(sql: str) -> str:
+    cleaned = re.sub(r"--.*", "", sql)
+    cleaned = re.sub(r"/\*.*?\*/", "", cleaned, flags=re.DOTALL)
+    cleaned = cleaned.strip().rstrip(";")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    cleaned = re.sub(r"\bpublic\.", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\bCREATE\s+OR\s+REPLACE\b", "CREATE", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\bIF\s+NOT\s+EXISTS\b", "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip().lower()
+
+
+def _schema_and_name(identifier: str) -> Tuple[Optional[str], str]:
+    identifier = identifier.strip()
+    if identifier.startswith("\"") and identifier.endswith("\""):
+        identifier = identifier[1:-1]
+    if "." in identifier:
+        schema, name = identifier.split(".", 1)
+        return schema.strip('"'), name.strip('"')
+    return None, identifier.strip('"')
+
+
+_HAS_PG_GET_TABLEDEF: Optional[bool] = None
+
+
+def _ensure_pg_get_tabledef(cursor) -> bool:
+    global _HAS_PG_GET_TABLEDEF
+    if _HAS_PG_GET_TABLEDEF is not None:
+        return _HAS_PG_GET_TABLEDEF
+    cursor.execute(
+        "SELECT EXISTS ("
+        "    SELECT 1"
+        "    FROM pg_proc p"
+        "    JOIN pg_namespace n ON n.oid = p.pronamespace"
+        "    WHERE n.nspname = 'pg_catalog'"
+        "      AND p.proname = 'pg_get_tabledef'"
+        ")"
+    )
+    _HAS_PG_GET_TABLEDEF = bool(cursor.fetchone()[0])
+    return _HAS_PG_GET_TABLEDEF
+
+
+def _existing_ddl(cursor, object_type: str, identifier: str, args: Optional[str]) -> Optional[str]:
+    object_type = object_type.upper()
+    if object_type in {"TABLE", "MATERIALIZED VIEW", "VIEW"}:
+        cursor.execute("SELECT to_regclass(%s)", (identifier,))
+        result = cursor.fetchone()
+        if not result or result[0] is None:
+            return None
+        regclass = str(result[0])
+        if object_type == "TABLE":
+            if not _ensure_pg_get_tabledef(cursor):
+                return None
+            cursor.execute("SELECT pg_get_tabledef(%s::regclass)", (regclass,))
+        elif object_type == "MATERIALIZED VIEW":
+            cursor.execute(
+                "SELECT 'CREATE MATERIALIZED VIEW ' || %s::regclass || ' AS ' || pg_get_viewdef(%s::regclass, true)",
+                (regclass, regclass),
+            )
+        else:
+            cursor.execute(
+                "SELECT 'CREATE VIEW ' || %s::regclass || ' AS ' || pg_get_viewdef(%s::regclass, true)",
+                (regclass, regclass),
+            )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    if object_type in {"FUNCTION", "PROCEDURE"}:
+        schema, name = _schema_and_name(identifier)
+        prokind = "f" if object_type == "FUNCTION" else "p"
+        params = [name]
+        query = [
+            "SELECT pg_get_functiondef(p.oid)",
+            "FROM pg_proc p",
+            "JOIN pg_namespace n ON n.oid = p.pronamespace",
+            "WHERE p.proname = %s",
+            "AND p.prokind = %s",
+        ]
+        params.append(prokind)
+        if schema:
+            query.append("AND n.nspname = %s")
+            params.append(schema)
+        if args is not None:
+            normalized_args = _normalize_function_args(args)
+            if normalized_args is not None:
+                query.append("AND pg_get_function_identity_arguments(p.oid) = %s")
+                params.append(normalized_args)
+        query.append("LIMIT 2")
+        cursor.execute("\n".join(query), params)
+        rows = cursor.fetchall()
+        if len(rows) != 1:
+            return None
+        return rows[0][0]
+
+    return None
+
+
+def _normalize_function_args(args: str) -> Optional[str]:
+    if args is None:
+        return None
+    args = args.strip()
+    if not args:
+        return ""
+    parts = []
+    for raw in args.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        token = token.split("=")[0].strip()
+        words = token.split()
+        cleaned: List[str] = []
+        for word in words:
+            upper = word.upper()
+            if upper in {"IN", "OUT", "INOUT", "VARIADIC"}:
+                continue
+            cleaned.append(word)
+        if not cleaned:
+            return None
+        # assume last elements describe the type possibly multi-word
+        # drop parameter name if more than one token
+        if len(cleaned) > 1:
+            type_tokens = cleaned[1:]
+        else:
+            type_tokens = cleaned
+        parts.append(" ".join(type_tokens))
+    return ", ".join(parts)
+
+
+def _identify_object(statement: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    match = CREATE_OBJECT_RE.match(statement.lstrip())
+    if not match:
+        return None, None, None
+    object_type = match.group("type").upper().replace("  ", " ")
+    name = match.group("name")
+    args = None
+    if object_type in {"FUNCTION", "PROCEDURE"}:
+        signature_match = re.search(r"\bFUNCTION\s+[^\s(]+\s*\((.*?)\)", statement, re.IGNORECASE | re.DOTALL)
+        if object_type == "PROCEDURE":
+            signature_match = re.search(r"\bPROCEDURE\s+[^\s(]+\s*\((.*?)\)", statement, re.IGNORECASE | re.DOTALL)
+        if signature_match:
+            args = signature_match.group(1)
+    return object_type, name, args
+
+
+def _definitions_equal(file_sql: str, database_sql: Optional[str]) -> bool:
+    if database_sql is None:
+        return False
+    return _normalize_sql(file_sql) == _normalize_sql(database_sql)
+
+
 def execute_file(cursor, path: Path) -> None:
     with path.open("r", encoding="utf-8") as handle:
         sql = handle.read()
-    print(f"Applying {path.relative_to(BASE_DIR)} ...")
-    cursor.execute(sql)
+
+    statements = _split_statements(sql)
+    relative_path = path.relative_to(BASE_DIR)
+    print(f"Inspecting {relative_path} for changes ...")
+
+    executed_any = False
+    for statement in statements:
+        object_type, name, args = _identify_object(statement)
+        if object_type and name:
+            existing = _existing_ddl(cursor, object_type, name, args)
+            if _definitions_equal(statement, existing):
+                print(
+                    f"  Skipping {object_type} {name}: no changes detected."
+                )
+                continue
+        cursor.execute(statement)
+        executed_any = True
+        if object_type and name:
+            print(f"  Applied {object_type} {name}.")
+    if not executed_any:
+        print(f"  No changes required for {relative_path}.")
 
 
 def deploy_stored_procedures(cursor) -> None:


### PR DESCRIPTION
## Summary
- add DDL-aware change detection in the bootstrapper so repeated runs skip unchanged objects while still executing updates
- normalize function/table definitions using pg_catalog helpers and preserve stored procedure deployment flow
- document the idempotent behavior in the database README and top-level guide for administrators

## Testing
- python -m compileall database/bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68daf8149e6c8327aa05006fa658137f