### PR TITLE
Brand Django admin as Rebec

### DIFF
--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend project initialization package."""

--- a/backend/backend/admin.py
+++ b/backend/backend/admin.py
@@ -1,0 +1,15 @@
+"""Admin site customizations for the backend project."""
+
+from __future__ import annotations
+
+from django.contrib import admin
+
+BRANDING_TEXT = "Rebec"
+
+
+def apply_admin_branding() -> None:
+    """Apply consistent branding to the Django admin site."""
+
+    admin.site.site_header = BRANDING_TEXT
+    admin.site.site_title = BRANDING_TEXT
+    admin.site.index_title = BRANDING_TEXT

--- a/backend/trials/apps.py
+++ b/backend/trials/apps.py
@@ -5,3 +5,8 @@ class TrialsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "trials"
     verbose_name = "Trials"
+
+    def ready(self) -> None:  # pragma: no cover - configuration
+        from backend.admin import apply_admin_branding
+
+        apply_admin_branding()


### PR DESCRIPTION
## Summary
- add a backend admin helper that centralises the Rebec branding text
- apply the branding during app initialisation so the admin UI shows the Rebec title

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dbd6e1d2b08327bc69e85159795392