### PR TITLE
Add trial creation workflow with formsets and persistence

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -3,10 +3,11 @@
 from django.contrib import admin
 from django.urls import path
 
-from trials.views import TrialListView
+from trials.views import TrialCreateView, TrialListView
 
 
 urlpatterns = [
     path("", TrialListView.as_view(), name="trial-list"),
+    path("trials/create/", TrialCreateView.as_view(), name="trial-create"),
     path("admin/", admin.site.urls),
 ]

--- a/backend/trials/forms.py
+++ b/backend/trials/forms.py
@@ -1,0 +1,186 @@
+"""Forms for managing clinical trial data."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from django import forms
+from django.forms import BaseFormSet, formset_factory
+from django.utils.translation import gettext_lazy as _
+
+
+ChoiceList = Sequence[tuple[str | int, str]]
+
+
+class TrialForm(forms.Form):
+    """Form describing the core trial details."""
+
+    public_identifier = forms.CharField(
+        label=_("Public identifier"),
+        max_length=255,
+        help_text=_("Unique identifier such as the registry number."),
+    )
+    official_title = forms.CharField(
+        label=_("Official title"),
+        widget=forms.Textarea(attrs={"rows": 2}),
+    )
+    brief_summary = forms.CharField(
+        label=_("Brief summary"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 4}),
+    )
+    recruitment_status_code = forms.ChoiceField(
+        label=_("Recruitment status"),
+        choices=(),
+    )
+    study_phase_code = forms.ChoiceField(
+        label=_("Study phase"),
+        required=False,
+        choices=(),
+    )
+    lead_sponsor_name = forms.CharField(
+        label=_("Lead sponsor name"),
+        required=False,
+        max_length=255,
+    )
+    lead_sponsor_type = forms.CharField(
+        label=_("Lead sponsor type"),
+        required=False,
+        max_length=255,
+    )
+    lead_sponsor_email = forms.EmailField(
+        label=_("Lead sponsor email"),
+        required=False,
+    )
+
+    def __init__(
+        self,
+        *args: object,
+        recruitment_status_choices: ChoiceList | None = None,
+        study_phase_choices: ChoiceList | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        recruitment_choices = [(str(value), label) for value, label in (recruitment_status_choices or [])]
+        study_phase_rendered = [(str(value), label) for value, label in (study_phase_choices or [])]
+        self.fields["recruitment_status_code"].choices = [
+            ("", _("Select a recruitment status")),
+            *recruitment_choices,
+        ]
+        self.fields["study_phase_code"].choices = [
+            ("", _("No study phase specified")),
+            *study_phase_rendered,
+        ]
+
+
+class TrialCountryForm(forms.Form):
+    country_id = forms.ChoiceField(label=_("Country"), choices=())
+    city = forms.CharField(label=_("City"), required=False, max_length=255)
+    site_name = forms.CharField(label=_("Site name"), required=False, max_length=255)
+
+    def __init__(
+        self,
+        *args: object,
+        country_choices: ChoiceList | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["country_id"].choices = self._with_placeholder(country_choices or [])
+
+    @staticmethod
+    def _with_placeholder(choices: ChoiceList) -> list[tuple[str, str]]:
+        return [("", _("Select a country"))] + [(str(value), label) for value, label in choices]
+
+
+class InterventionForm(forms.Form):
+    name = forms.CharField(label=_("Name"), max_length=255)
+    intervention_type_id = forms.ChoiceField(label=_("Type"), choices=())
+    description = forms.CharField(
+        label=_("Description"),
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2}),
+    )
+
+    def __init__(
+        self,
+        *args: object,
+        intervention_type_choices: ChoiceList | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["intervention_type_id"].choices = self._with_placeholder(
+            intervention_type_choices or [],
+            placeholder=_("Select an intervention type"),
+        )
+
+    @staticmethod
+    def _with_placeholder(choices: ChoiceList, *, placeholder: str) -> list[tuple[str, str]]:
+        return [("", placeholder)] + [(str(value), label) for value, label in choices]
+
+
+class TrialConditionForm(forms.Form):
+    condition_name = forms.CharField(label=_("Condition name"), max_length=255)
+    condition_category_id = forms.ChoiceField(
+        label=_("Condition category"),
+        required=False,
+        choices=(),
+    )
+
+    def __init__(
+        self,
+        *args: object,
+        condition_category_choices: ChoiceList | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["condition_category_id"].choices = self._with_placeholder(
+            condition_category_choices or [],
+            placeholder=_("Select a category"),
+        )
+
+    @staticmethod
+    def _with_placeholder(choices: ChoiceList, *, placeholder: str) -> list[tuple[str, str]]:
+        return [("", placeholder)] + [(str(value), label) for value, label in choices]
+
+
+class TrialDocumentForm(forms.Form):
+    document_type = forms.CharField(label=_("Document type"), max_length=255)
+    document_url = forms.URLField(label=_("Document URL"))
+    is_confidential = forms.BooleanField(label=_("Confidential"), required=False)
+
+
+class BaseOptionalFormSet(BaseFormSet):
+    """Base formset that ignores forms with no changed data."""
+
+    def clean(self) -> None:  # pragma: no cover - default implementation is sufficient
+        super().clean()
+
+
+TrialCountryFormSet = formset_factory(
+    TrialCountryForm,
+    extra=1,
+    can_delete=True,
+    formset=BaseOptionalFormSet,
+)
+
+InterventionFormSet = formset_factory(
+    InterventionForm,
+    extra=1,
+    can_delete=True,
+    formset=BaseOptionalFormSet,
+)
+
+TrialConditionFormSet = formset_factory(
+    TrialConditionForm,
+    extra=1,
+    can_delete=True,
+    formset=BaseOptionalFormSet,
+)
+
+TrialDocumentFormSet = formset_factory(
+    TrialDocumentForm,
+    extra=1,
+    can_delete=True,
+    formset=BaseOptionalFormSet,
+)
+

--- a/backend/trials/templates/admin/trial_form.html
+++ b/backend/trials/templates/admin/trial_form.html
@@ -1,0 +1,138 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Create Trial" %}{% endblock %}
+
+{% block content %}
+<div class="module">
+  <h2>{% trans "Create Trial" %}</h2>
+  {% if save_error %}
+  <p class="errornote">{% trans "There was a problem saving the trial. Please review the form and try again." %}</p>
+  {% endif %}
+  <form method="post" novalidate>
+    {% csrf_token %}
+    {% if trial_form.non_field_errors %}
+    <div class="errornote">
+      {{ trial_form.non_field_errors|join:" " }}
+    </div>
+    {% endif %}
+    <fieldset class="module aligned">
+      {% for field in trial_form %}
+      <div class="form-row{% if field.errors %} errors{% endif %}">
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}
+        <p class="help">{{ field.help_text }}</p>
+        {% endif %}
+        {% for error in field.errors %}
+        <p class="errornote">{{ error }}</p>
+        {% endfor %}
+      </div>
+      {% endfor %}
+    </fieldset>
+
+    {% for config in formsets %}
+    <div class="inline-group" data-formset-prefix="{{ config.formset.prefix }}">
+      <h3>{{ config.title }}</h3>
+      {{ config.formset.management_form }}
+      {% if config.formset.non_form_errors %}
+      <div class="errornote">
+        {{ config.formset.non_form_errors|join:" " }}
+      </div>
+      {% endif %}
+      <div data-formset-forms>
+        {% for form in config.formset %}
+        <div class="inline-related{% if form.errors %} errors{% endif %}" data-formset-form>
+          {% for hidden in form.hidden_fields %}
+          {{ hidden }}
+          {% endfor %}
+          <fieldset class="module aligned">
+            {% for field in form.visible_fields %}
+            <div class="form-row{% if field.errors %} errors{% endif %}">
+              {{ field.label_tag }}
+              {{ field }}
+              {% for error in field.errors %}
+              <p class="errornote">{{ error }}</p>
+              {% endfor %}
+            </div>
+            {% endfor %}
+            {% if config.formset.can_delete %}
+            <div class="form-row delete-row">
+              {{ form.DELETE }}
+              <label for="{{ form.DELETE.id_for_label }}">{% trans "Delete" %}</label>
+            </div>
+            {% endif %}
+          </fieldset>
+          {% if form.non_field_errors %}
+          <div class="errornote">
+            {{ form.non_field_errors|join:" " }}
+          </div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      <template data-empty-form>
+        <div class="inline-related" data-formset-form>
+          {% with form=config.formset.empty_form %}
+          {% for hidden in form.hidden_fields %}
+          {{ hidden.as_widget }}
+          {% endfor %}
+          <fieldset class="module aligned">
+            {% for field in form.visible_fields %}
+            <div class="form-row">
+              {{ field.label_tag }}
+              {{ field.as_widget }}
+            </div>
+            {% endfor %}
+            {% if config.formset.can_delete %}
+            <div class="form-row delete-row">
+              {{ form.DELETE.as_widget }}
+              <label for="{{ form.DELETE.id_for_label }}">{% trans "Delete" %}</label>
+            </div>
+            {% endif %}
+          </fieldset>
+          {% endwith %}
+        </div>
+      </template>
+      <p class="add-row"><a href="#" data-add-inline>{{ config.add_text }}</a></p>
+    </div>
+    {% endfor %}
+
+    <div class="submit-row">
+      <button type="submit" class="default">{% trans "Save" %}</button>
+      <a class="button cancel-link" href="{% url 'trial-list' %}">{% trans "Cancel" %}</a>
+    </div>
+  </form>
+</div>
+
+<script>
+(function() {
+  document.querySelectorAll('[data-formset-prefix]').forEach(function(container) {
+    const prefix = container.getAttribute('data-formset-prefix');
+    const addButton = container.querySelector('[data-add-inline]');
+    const template = container.querySelector('template[data-empty-form]');
+    const formsContainer = container.querySelector('[data-formset-forms]');
+    if (!addButton || !template || !formsContainer) {
+      return;
+    }
+    const totalFormsInput = container.querySelector('input[name="' + prefix + '-TOTAL_FORMS"]');
+    if (!totalFormsInput) {
+      return;
+    }
+    addButton.addEventListener('click', function(event) {
+      event.preventDefault();
+      const currentIndex = parseInt(totalFormsInput.value, 10) || 0;
+      const markup = template.innerHTML.replace(/__prefix__/g, currentIndex);
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = markup;
+      const newForm = wrapper.firstElementChild;
+      if (!newForm) {
+        return;
+      }
+      formsContainer.appendChild(newForm);
+      totalFormsInput.value = currentIndex + 1;
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/backend/trials/templates/admin/trials_list.html
+++ b/backend/trials/templates/admin/trials_list.html
@@ -9,7 +9,7 @@
   <div class="module-header">
     <h2>{% trans "Trials" %}</h2>
     {% if user.is_authenticated %}
-    <a class="button" href="{% url 'admin:index' %}">{% trans "Create Trial" %}</a>
+    <a class="button" href="{% url 'trial-create' %}">{% trans "Create Trial" %}</a>
     {% endif %}
   </div>
   {% if load_error %}

--- a/backend/trials/views.py
+++ b/backend/trials/views.py
@@ -4,7 +4,21 @@ import json
 from typing import Any
 
 from django.db import connection
+from django.db import transaction
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse_lazy
 from django.views.generic import TemplateView
+from django.utils.translation import gettext_lazy as _
+
+from .forms import (
+    InterventionFormSet,
+    TrialConditionFormSet,
+    TrialCountryFormSet,
+    TrialDocumentFormSet,
+    TrialForm,
+)
 
 
 class TrialListView(TemplateView):
@@ -49,3 +63,274 @@ class TrialListView(TemplateView):
             except json.JSONDecodeError:
                 return []
         return raw_payload
+
+
+class TrialCreateView(LoginRequiredMixin, TemplateView):
+    template_name = "admin/trial_form.html"
+    success_url = reverse_lazy("trial-list")
+
+    reference_data: dict[str, list[tuple[Any, str]]]
+
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        self.reference_data = self._load_reference_data()
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        trial_form = self._build_trial_form()
+        country_formset = self._build_country_formset()
+        intervention_formset = self._build_intervention_formset()
+        condition_formset = self._build_condition_formset()
+        document_formset = self._build_document_formset()
+        context = self._build_context(
+            trial_form,
+            country_formset,
+            intervention_formset,
+            condition_formset,
+            document_formset,
+        )
+        return self.render_to_response(context)
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        trial_form = self._build_trial_form(data=request.POST)
+        country_formset = self._build_country_formset(data=request.POST)
+        intervention_formset = self._build_intervention_formset(data=request.POST)
+        condition_formset = self._build_condition_formset(data=request.POST)
+        document_formset = self._build_document_formset(data=request.POST)
+
+        trial_valid = trial_form.is_valid()
+        country_valid = country_formset.is_valid()
+        intervention_valid = intervention_formset.is_valid()
+        condition_valid = condition_formset.is_valid()
+        document_valid = document_formset.is_valid()
+
+        if trial_valid and country_valid and intervention_valid and condition_valid and document_valid:
+            try:
+                with transaction.atomic():
+                    trial_id = self._create_trial(trial_form.cleaned_data)
+                    self._save_countries(trial_id, country_formset.cleaned_data)
+                    self._save_interventions(trial_id, intervention_formset.cleaned_data)
+                    self._save_conditions(trial_id, condition_formset.cleaned_data)
+                    self._save_documents(trial_id, document_formset.cleaned_data)
+            except Exception:  # pragma: no cover - defensive; logging could be added later
+                context = self._build_context(
+                    trial_form,
+                    country_formset,
+                    intervention_formset,
+                    condition_formset,
+                    document_formset,
+                    save_error=True,
+                )
+                return self.render_to_response(context)
+            return redirect(self.success_url)
+
+        context = self._build_context(
+            trial_form,
+            country_formset,
+            intervention_formset,
+            condition_formset,
+            document_formset,
+        )
+        return self.render_to_response(context)
+
+    def _build_context(
+        self,
+        trial_form: TrialForm,
+        country_formset: TrialCountryFormSet,
+        intervention_formset: InterventionFormSet,
+        condition_formset: TrialConditionFormSet,
+        document_formset: TrialDocumentFormSet,
+        *,
+        save_error: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "trial_form": trial_form,
+            "formsets": [
+                {
+                    "title": _("Locations"),
+                    "add_text": _("Add another location"),
+                    "formset": country_formset,
+                },
+                {
+                    "title": _("Interventions"),
+                    "add_text": _("Add another intervention"),
+                    "formset": intervention_formset,
+                },
+                {
+                    "title": _("Conditions"),
+                    "add_text": _("Add another condition"),
+                    "formset": condition_formset,
+                },
+                {
+                    "title": _("Documents"),
+                    "add_text": _("Add another document"),
+                    "formset": document_formset,
+                },
+            ],
+            "save_error": save_error,
+        }
+
+    def _build_trial_form(self, data: dict[str, Any] | None = None) -> TrialForm:
+        return TrialForm(
+            data=data,
+            recruitment_status_choices=self.reference_data.get("recruitment_statuses", []),
+            study_phase_choices=self.reference_data.get("study_phases", []),
+        )
+
+    def _build_country_formset(self, data: dict[str, Any] | None = None) -> TrialCountryFormSet:
+        return TrialCountryFormSet(
+            data=data,
+            prefix="countries",
+            form_kwargs={"country_choices": self.reference_data.get("countries", [])},
+        )
+
+    def _build_intervention_formset(self, data: dict[str, Any] | None = None) -> InterventionFormSet:
+        return InterventionFormSet(
+            data=data,
+            prefix="interventions",
+            form_kwargs={
+                "intervention_type_choices": self.reference_data.get("intervention_types", [])
+            },
+        )
+
+    def _build_condition_formset(self, data: dict[str, Any] | None = None) -> TrialConditionFormSet:
+        return TrialConditionFormSet(
+            data=data,
+            prefix="conditions",
+            form_kwargs={
+                "condition_category_choices": self.reference_data.get("condition_categories", [])
+            },
+        )
+
+    def _build_document_formset(self, data: dict[str, Any] | None = None) -> TrialDocumentFormSet:
+        return TrialDocumentFormSet(data=data, prefix="documents")
+
+    def _load_reference_data(self) -> dict[str, list[tuple[Any, str]]]:
+        reference_data: dict[str, list[tuple[Any, str]]] = {
+            "recruitment_statuses": [],
+            "study_phases": [],
+            "countries": [],
+            "intervention_types": [],
+            "condition_categories": [],
+        }
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT status_code, COALESCE(description, status_code)"
+                " FROM recruitment_statuses ORDER BY description, status_code"
+            )
+            reference_data["recruitment_statuses"] = [(row[0], row[1]) for row in cursor.fetchall()]
+
+            cursor.execute(
+                "SELECT phase_code, COALESCE(description, phase_code)"
+                " FROM study_phases ORDER BY description, phase_code"
+            )
+            reference_data["study_phases"] = [(row[0], row[1]) for row in cursor.fetchall()]
+
+            cursor.execute(
+                "SELECT country_id, name FROM countries ORDER BY name"
+            )
+            reference_data["countries"] = [(row[0], row[1]) for row in cursor.fetchall()]
+
+            cursor.execute(
+                "SELECT intervention_type_id, COALESCE(description, type_code)"
+                " FROM intervention_types ORDER BY description, type_code"
+            )
+            reference_data["intervention_types"] = [(row[0], row[1]) for row in cursor.fetchall()]
+
+            cursor.execute(
+                "SELECT condition_category_id, COALESCE(name, category_code)"
+                " FROM condition_categories ORDER BY name, category_code"
+            )
+            reference_data["condition_categories"] = [(row[0], row[1]) for row in cursor.fetchall()]
+
+        return reference_data
+
+    def _create_trial(self, cleaned_data: dict[str, Any]) -> int:
+        with connection.cursor() as cursor:
+            cursor.callproc(
+                "create_trial",
+                [
+                    cleaned_data.get("public_identifier"),
+                    cleaned_data.get("official_title"),
+                    cleaned_data.get("recruitment_status_code"),
+                    cleaned_data.get("study_phase_code") or None,
+                    cleaned_data.get("brief_summary") or None,
+                    cleaned_data.get("lead_sponsor_name") or None,
+                    cleaned_data.get("lead_sponsor_type") or None,
+                    cleaned_data.get("lead_sponsor_email") or None,
+                ],
+            )
+            cursor.execute(
+                "SELECT trial_id FROM trials WHERE public_identifier = %s ORDER BY trial_id DESC LIMIT 1",
+                [cleaned_data.get("public_identifier")],
+            )
+            row = cursor.fetchone()
+        if not row:
+            raise ValueError("Failed to determine the created trial identifier")
+        return int(row[0])
+
+    def _save_countries(self, trial_id: int, cleaned_data: list[dict[str, Any]]) -> None:
+        with connection.cursor() as cursor:
+            for form_data in cleaned_data:
+                if not form_data or form_data.get("DELETE"):
+                    continue
+                country_id = form_data.get("country_id")
+                if not country_id:
+                    continue
+                city = form_data.get("city") or None
+                site_name = form_data.get("site_name") or None
+                cursor.execute(
+                    "INSERT INTO trial_countries (trial_id, country_id, city, site_name)"
+                    " VALUES (%s, %s, %s, %s)",
+                    [trial_id, int(country_id), city, site_name],
+                )
+
+    def _save_interventions(self, trial_id: int, cleaned_data: list[dict[str, Any]]) -> None:
+        with connection.cursor() as cursor:
+            for form_data in cleaned_data:
+                if not form_data or form_data.get("DELETE"):
+                    continue
+                intervention_type_id = form_data.get("intervention_type_id")
+                name = form_data.get("name")
+                if not intervention_type_id or not name:
+                    continue
+                description = form_data.get("description") or None
+                cursor.execute(
+                    "INSERT INTO interventions (trial_id, intervention_type_id, name, description)"
+                    " VALUES (%s, %s, %s, %s)",
+                    [trial_id, int(intervention_type_id), name, description],
+                )
+
+    def _save_conditions(self, trial_id: int, cleaned_data: list[dict[str, Any]]) -> None:
+        with connection.cursor() as cursor:
+            for form_data in cleaned_data:
+                if not form_data or form_data.get("DELETE"):
+                    continue
+                condition_name = form_data.get("condition_name")
+                if not condition_name:
+                    continue
+                condition_category_id = form_data.get("condition_category_id") or None
+                cursor.execute(
+                    "INSERT INTO trial_conditions (trial_id, condition_category_id, condition_name)"
+                    " VALUES (%s, %s, %s)",
+                    [
+                        trial_id,
+                        int(condition_category_id) if condition_category_id else None,
+                        condition_name,
+                    ],
+                )
+
+    def _save_documents(self, trial_id: int, cleaned_data: list[dict[str, Any]]) -> None:
+        with connection.cursor() as cursor:
+            for form_data in cleaned_data:
+                if not form_data or form_data.get("DELETE"):
+                    continue
+                document_type = form_data.get("document_type")
+                document_url = form_data.get("document_url")
+                if not document_type or not document_url:
+                    continue
+                is_confidential = bool(form_data.get("is_confidential"))
+                cursor.execute(
+                    "INSERT INTO trial_documents (trial_id, document_type, document_url, is_confidential)"
+                    " VALUES (%s, %s, %s, %s)",
+                    [trial_id, document_type, document_url, is_confidential],
+                )


### PR DESCRIPTION
## Summary
- add a login-protected trial creation view that saves core trial data and related records via stored procedures and SQL
- implement dedicated forms and inline-style formsets to capture locations, interventions, conditions, and documents
- expose the create view at a new URL and link the Trials list button to the new page

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dbd6ea5ae483279cb7d2e8bdda5ac2