### PR TITLE
Fix ChoiceList typing to avoid runtime unions

### DIFF
--- a/backend/trials/forms.py
+++ b/backend/trials/forms.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Sequence, Tuple, Union
 
 from django import forms
 from django.forms import BaseFormSet, formset_factory
 from django.utils.translation import gettext_lazy as _
 
 
-ChoiceList = Sequence[tuple[str | int, str]]
+ChoiceList = Sequence[Tuple[Union[str, int], str]]
 
 
 class TrialForm(forms.Form):


### PR DESCRIPTION
## Summary
- import Tuple and Union for the ChoiceList alias in trials forms
- update ChoiceList typing to avoid the runtime `|` operator

## Testing
- python backend/manage.py runserver --noreload

------
https://chatgpt.com/codex/tasks/task_e_68dbdc00a1008327b56fe3822202b049