### PR TITLE
Replace clinical trial schema with ct dump and align vocabulary tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ The workflow of the clinical trials registry is as follows:
 
 The PostgreSQL assets that ship with the project live under `database/`:
 
-- `database/sql/vocabulary_tables.sql` defines reference data such as `countries`,
-  `recruitment_statuses`, `intervention_types`, `study_phases`, and
-  `condition_categories`.
-- `database/sql/clinical_trial_tables.sql` provisions the core `trials`
-  relations, including `trials`, `trial_countries`, `interventions`,
-  `trial_conditions`, `trial_documents`, and related sponsor lookups.
+- `database/sql/vocabulary_tables.sql` defines reference data such as
+  `vocabulary_country`, `vocabulary_recruitment_status`,
+  `vocabulary_intervention_type`, `vocabulary_study_phase`, and
+  `vocabulary_condition_category`.
+- `database/sql/clinical_trial_tables.sql` provisions the core `ct`
+  relations, including `trials`, `research_institutions`,
+  `trial_countries`, `interventions`, `trial_conditions`,
+  `trial_documents`, status history tracking, and related sponsor lookups.
 - `database/sql/supporting_objects.sql` adds cross-cutting helpers (e.g. the
   `set_updated_at` trigger) that keep timestamps current.
 - `database/sql/vocabulary_seed.sql` pre-populates controlled vocabularies for
@@ -66,8 +68,9 @@ individual scripts:
 
 ### Key schema components
 
-- **Vocabulary tables:** `countries`, `recruitment_statuses`, `intervention_types`,
-  `study_phases`, `condition_categories`.
+- **Vocabulary tables:** `vocabulary_country`,
+  `vocabulary_recruitment_status`, `vocabulary_intervention_type`,
+  `vocabulary_study_phase`, `vocabulary_condition_category`.
 - **Core `ct_*` tables:** `trials`, `trial_countries`, `trial_conditions`,
   `trial_documents`, `interventions`, and supporting `sponsors` relations.
 - **Supporting functions and procedures:** `set_updated_at` trigger function,

--- a/backend/trials/views.py
+++ b/backend/trials/views.py
@@ -214,31 +214,31 @@ class TrialCreateView(LoginRequiredMixin, TemplateView):
         }
         with connection.cursor() as cursor:
             cursor.execute(
-                "SELECT status_code, COALESCE(description, status_code)"
-                " FROM recruitment_statuses ORDER BY description, status_code"
+                "SELECT code, COALESCE(description, code)"
+                " FROM vocabulary_recruitment_status ORDER BY description, code"
             )
             reference_data["recruitment_statuses"] = [(row[0], row[1]) for row in cursor.fetchall()]
 
             cursor.execute(
-                "SELECT phase_code, COALESCE(description, phase_code)"
-                " FROM study_phases ORDER BY description, phase_code"
+                "SELECT code, COALESCE(description, code)"
+                " FROM vocabulary_study_phase ORDER BY description, code"
             )
             reference_data["study_phases"] = [(row[0], row[1]) for row in cursor.fetchall()]
 
             cursor.execute(
-                "SELECT country_id, name FROM countries ORDER BY name"
+                "SELECT id, name FROM vocabulary_country ORDER BY name"
             )
             reference_data["countries"] = [(row[0], row[1]) for row in cursor.fetchall()]
 
             cursor.execute(
-                "SELECT intervention_type_id, COALESCE(description, type_code)"
-                " FROM intervention_types ORDER BY description, type_code"
+                "SELECT id, COALESCE(description, code)"
+                " FROM vocabulary_intervention_type ORDER BY description, code"
             )
             reference_data["intervention_types"] = [(row[0], row[1]) for row in cursor.fetchall()]
 
             cursor.execute(
-                "SELECT condition_category_id, COALESCE(name, category_code)"
-                " FROM condition_categories ORDER BY name, category_code"
+                "SELECT id, COALESCE(name, code)"
+                " FROM vocabulary_condition_category ORDER BY name, code"
             )
             reference_data["condition_categories"] = [(row[0], row[1]) for row in cursor.fetchall()]
 
@@ -257,6 +257,7 @@ class TrialCreateView(LoginRequiredMixin, TemplateView):
                     cleaned_data.get("lead_sponsor_name") or None,
                     cleaned_data.get("lead_sponsor_type") or None,
                     cleaned_data.get("lead_sponsor_email") or None,
+                    None,
                 ],
             )
             cursor.execute(

--- a/database/README.md
+++ b/database/README.md
@@ -5,9 +5,9 @@ clinical trial administration database.
 
 ## Contents
 
-- `sql/` — schema definition and seed data scripts executed in order by the
+ - `sql/` — schema definition and seed data scripts executed in order by the
   bootstrapper:
-  1. `vocabulary_tables.sql` — controlled vocabularies (countries,
+  1. `vocabulary_tables.sql` — controlled vocabularies (vocabulary_country,
      recruitment statuses, etc.).
   2. `auth_tables_postgres.sql` — Django authentication and content type
      tables compatible with PostgreSQL.

--- a/database/sql/clinical_trial_tables.sql
+++ b/database/sql/clinical_trial_tables.sql
@@ -1,60 +1,388 @@
--- Core clinical trial tables that rely on the vocabulary tables.
+-- Clinical trial schema extracted from ct schema dump
+-- Recreates tables, sequences, defaults, primary keys, foreign keys, and indexes.
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', 'public', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: sponsors; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS sponsors (
-    sponsor_id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE,
-    sponsor_type TEXT,
-    contact_email TEXT
+    sponsor_id integer NOT NULL,
+    name text NOT NULL,
+    sponsor_type text,
+    contact_email text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+CREATE SEQUENCE IF NOT EXISTS sponsors_sponsor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE sponsors_sponsor_id_seq OWNED BY sponsors.sponsor_id;
+
+ALTER TABLE ONLY sponsors ALTER COLUMN sponsor_id SET DEFAULT nextval('sponsors_sponsor_id_seq'::regclass);
+
+ALTER TABLE ONLY sponsors
+    ADD CONSTRAINT sponsors_pkey PRIMARY KEY (sponsor_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sponsors_name_lower_idx ON sponsors (lower(name));
+
+--
+-- Name: research_institutions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS research_institutions (
+    research_institution_id integer NOT NULL,
+    name text NOT NULL,
+    institution_type text,
+    country_id integer NOT NULL,
+    city text,
+    state_province text,
+    postal_code text,
+    contact_email text,
+    phone text,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS research_institutions_research_institution_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE research_institutions_research_institution_id_seq OWNED BY research_institutions.research_institution_id;
+
+ALTER TABLE ONLY research_institutions
+    ALTER COLUMN research_institution_id SET DEFAULT nextval('research_institutions_research_institution_id_seq'::regclass);
+
+ALTER TABLE ONLY research_institutions
+    ADD CONSTRAINT research_institutions_pkey PRIMARY KEY (research_institution_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS research_institutions_name_country_idx
+    ON research_institutions (lower(name), country_id, COALESCE(lower(city), ''), COALESCE(lower(state_province), ''));
+
+ALTER TABLE ONLY research_institutions
+    ADD CONSTRAINT research_institutions_country_id_fkey FOREIGN KEY (country_id) REFERENCES vocabulary_country(id);
+
+--
+-- Name: trials; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS trials (
-    trial_id SERIAL PRIMARY KEY,
-    public_identifier TEXT NOT NULL UNIQUE,
-    official_title TEXT NOT NULL,
-    brief_summary TEXT,
-    recruitment_status_id INTEGER NOT NULL REFERENCES recruitment_statuses(recruitment_status_id),
-    study_phase_id INTEGER REFERENCES study_phases(study_phase_id),
-    primary_completion_date DATE,
-    overall_completion_date DATE,
-    lead_sponsor_id INTEGER REFERENCES sponsors(sponsor_id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    trial_id integer NOT NULL,
+    public_identifier text NOT NULL,
+    official_title text NOT NULL,
+    brief_summary text,
+    recruitment_status_id integer NOT NULL,
+    study_phase_id integer,
+    lead_sponsor_id integer,
+    responsible_institution_id integer,
+    primary_completion_date date,
+    overall_completion_date date,
+    enrollment_actual integer,
+    enrollment_target integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+CREATE SEQUENCE IF NOT EXISTS trials_trial_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trials_trial_id_seq OWNED BY trials.trial_id;
+
+ALTER TABLE ONLY trials ALTER COLUMN trial_id SET DEFAULT nextval('trials_trial_id_seq'::regclass);
+
+ALTER TABLE ONLY trials
+    ADD CONSTRAINT trials_pkey PRIMARY KEY (trial_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trials_public_identifier_lower_idx ON trials (lower(public_identifier));
+
+ALTER TABLE ONLY trials
+    ADD CONSTRAINT trials_lead_sponsor_id_fkey FOREIGN KEY (lead_sponsor_id) REFERENCES sponsors(sponsor_id);
+
+ALTER TABLE ONLY trials
+    ADD CONSTRAINT trials_recruitment_status_id_fkey FOREIGN KEY (recruitment_status_id) REFERENCES vocabulary_recruitment_status(id);
+
+ALTER TABLE ONLY trials
+    ADD CONSTRAINT trials_responsible_institution_id_fkey FOREIGN KEY (responsible_institution_id) REFERENCES research_institutions(research_institution_id);
+
+ALTER TABLE ONLY trials
+    ADD CONSTRAINT trials_study_phase_id_fkey FOREIGN KEY (study_phase_id) REFERENCES vocabulary_study_phase(id);
+
+--
+-- Name: trial_countries; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS trial_countries (
-    trial_country_id SERIAL PRIMARY KEY,
-    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
-    country_id INTEGER NOT NULL REFERENCES countries(country_id),
-    city TEXT,
-    site_name TEXT
+    trial_country_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    country_id integer NOT NULL,
+    city text,
+    site_name text,
+    research_institution_id integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+CREATE SEQUENCE IF NOT EXISTS trial_countries_trial_country_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_countries_trial_country_id_seq OWNED BY trial_countries.trial_country_id;
+
+ALTER TABLE ONLY trial_countries ALTER COLUMN trial_country_id SET DEFAULT nextval('trial_countries_trial_country_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_countries
+    ADD CONSTRAINT trial_countries_pkey PRIMARY KEY (trial_country_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS trial_countries_unique_idx
-    ON trial_countries (trial_id, country_id, COALESCE(city, ''), COALESCE(site_name, ''));
+    ON trial_countries (trial_id, country_id, COALESCE(lower(city), ''), COALESCE(lower(site_name), ''), COALESCE(research_institution_id, 0));
+
+ALTER TABLE ONLY trial_countries
+    ADD CONSTRAINT trial_countries_country_id_fkey FOREIGN KEY (country_id) REFERENCES vocabulary_country(id);
+
+ALTER TABLE ONLY trial_countries
+    ADD CONSTRAINT trial_countries_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY trial_countries
+    ADD CONSTRAINT trial_countries_research_institution_id_fkey FOREIGN KEY (research_institution_id) REFERENCES research_institutions(research_institution_id) ON DELETE SET NULL;
+
+--
+-- Name: interventions; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS interventions (
-    intervention_id SERIAL PRIMARY KEY,
-    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
-    intervention_type_id INTEGER NOT NULL REFERENCES intervention_types(intervention_type_id),
-    name TEXT NOT NULL,
-    description TEXT,
-    UNIQUE (trial_id, name)
+    intervention_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    intervention_type_id integer NOT NULL,
+    name text NOT NULL,
+    description text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+CREATE SEQUENCE IF NOT EXISTS interventions_intervention_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE interventions_intervention_id_seq OWNED BY interventions.intervention_id;
+
+ALTER TABLE ONLY interventions ALTER COLUMN intervention_id SET DEFAULT nextval('interventions_intervention_id_seq'::regclass);
+
+ALTER TABLE ONLY interventions
+    ADD CONSTRAINT interventions_pkey PRIMARY KEY (intervention_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS interventions_trial_id_name_key
+    ON interventions (trial_id, lower(name));
+
+ALTER TABLE ONLY interventions
+    ADD CONSTRAINT interventions_intervention_type_id_fkey FOREIGN KEY (intervention_type_id) REFERENCES vocabulary_intervention_type(id);
+
+ALTER TABLE ONLY interventions
+    ADD CONSTRAINT interventions_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+--
+-- Name: trial_conditions; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE IF NOT EXISTS trial_conditions (
-    trial_condition_id SERIAL PRIMARY KEY,
-    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
-    condition_category_id INTEGER REFERENCES condition_categories(condition_category_id),
-    condition_name TEXT NOT NULL,
-    UNIQUE (trial_id, condition_name)
+    trial_condition_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    condition_category_id integer,
+    condition_name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
+CREATE SEQUENCE IF NOT EXISTS trial_conditions_trial_condition_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_conditions_trial_condition_id_seq OWNED BY trial_conditions.trial_condition_id;
+
+ALTER TABLE ONLY trial_conditions ALTER COLUMN trial_condition_id SET DEFAULT nextval('trial_conditions_trial_condition_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_conditions
+    ADD CONSTRAINT trial_conditions_pkey PRIMARY KEY (trial_condition_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trial_conditions_trial_id_condition_name_key
+    ON trial_conditions (trial_id, lower(condition_name));
+
+ALTER TABLE ONLY trial_conditions
+    ADD CONSTRAINT trial_conditions_condition_category_id_fkey FOREIGN KEY (condition_category_id) REFERENCES vocabulary_condition_category(id);
+
+ALTER TABLE ONLY trial_conditions
+    ADD CONSTRAINT trial_conditions_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+--
+-- Name: trial_documents; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE IF NOT EXISTS trial_documents (
-    trial_document_id SERIAL PRIMARY KEY,
-    trial_id INTEGER NOT NULL REFERENCES trials(trial_id) ON DELETE CASCADE,
-    document_type TEXT NOT NULL,
-    document_url TEXT NOT NULL,
-    is_confidential BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    trial_document_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    document_type text NOT NULL,
+    document_url text NOT NULL,
+    is_confidential boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+CREATE SEQUENCE IF NOT EXISTS trial_documents_trial_document_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_documents_trial_document_id_seq OWNED BY trial_documents.trial_document_id;
+
+ALTER TABLE ONLY trial_documents ALTER COLUMN trial_document_id SET DEFAULT nextval('trial_documents_trial_document_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_documents
+    ADD CONSTRAINT trial_documents_pkey PRIMARY KEY (trial_document_id);
+
+ALTER TABLE ONLY trial_documents
+    ADD CONSTRAINT trial_documents_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+--
+-- Name: trial_contacts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS trial_contacts (
+    trial_contact_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    contact_type text NOT NULL,
+    given_name text,
+    family_name text,
+    email text,
+    phone text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS trial_contacts_trial_contact_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_contacts_trial_contact_id_seq OWNED BY trial_contacts.trial_contact_id;
+
+ALTER TABLE ONLY trial_contacts ALTER COLUMN trial_contact_id SET DEFAULT nextval('trial_contacts_trial_contact_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_contacts
+    ADD CONSTRAINT trial_contacts_pkey PRIMARY KEY (trial_contact_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trial_contacts_unique_idx
+    ON trial_contacts (trial_id, lower(COALESCE(email, '')), lower(COALESCE(phone, '')), contact_type);
+
+ALTER TABLE ONLY trial_contacts
+    ADD CONSTRAINT trial_contacts_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+--
+-- Name: trial_status_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS trial_status_history (
+    trial_status_history_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    recruitment_status_id integer NOT NULL,
+    status_date date NOT NULL,
+    note text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS trial_status_history_trial_status_history_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_status_history_trial_status_history_id_seq OWNED BY trial_status_history.trial_status_history_id;
+
+ALTER TABLE ONLY trial_status_history ALTER COLUMN trial_status_history_id SET DEFAULT nextval('trial_status_history_trial_status_history_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_status_history
+    ADD CONSTRAINT trial_status_history_pkey PRIMARY KEY (trial_status_history_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trial_status_history_unique_idx
+    ON trial_status_history (trial_id, recruitment_status_id, status_date);
+
+ALTER TABLE ONLY trial_status_history
+    ADD CONSTRAINT trial_status_history_recruitment_status_id_fkey FOREIGN KEY (recruitment_status_id) REFERENCES vocabulary_recruitment_status(id);
+
+ALTER TABLE ONLY trial_status_history
+    ADD CONSTRAINT trial_status_history_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+
+--
+-- Name: trial_identifiers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS trial_identifiers (
+    trial_identifier_id integer NOT NULL,
+    trial_id integer NOT NULL,
+    identifier_type text NOT NULL,
+    identifier_value text NOT NULL,
+    issued_by text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS trial_identifiers_trial_identifier_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE trial_identifiers_trial_identifier_id_seq OWNED BY trial_identifiers.trial_identifier_id;
+
+ALTER TABLE ONLY trial_identifiers ALTER COLUMN trial_identifier_id SET DEFAULT nextval('trial_identifiers_trial_identifier_id_seq'::regclass);
+
+ALTER TABLE ONLY trial_identifiers
+    ADD CONSTRAINT trial_identifiers_pkey PRIMARY KEY (trial_identifier_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trial_identifiers_unique_idx
+    ON trial_identifiers (trial_id, lower(identifier_type), lower(identifier_value));
+
+ALTER TABLE ONLY trial_identifiers
+    ADD CONSTRAINT trial_identifiers_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
 

--- a/database/sql/vocabulary_seed.sql
+++ b/database/sql/vocabulary_seed.sql
@@ -1,6 +1,6 @@
--- Seed data for vocabulary tables
+-- Seed data for vocabulary tables aligned with ct schema naming
 
-INSERT INTO countries (iso_alpha2, iso_alpha3, name) VALUES
+INSERT INTO vocabulary_country (iso_alpha2, iso_alpha3, name) VALUES
     ('US', 'USA', 'United States'),
     ('CA', 'CAN', 'Canada'),
     ('GB', 'GBR', 'United Kingdom'),
@@ -8,35 +8,35 @@ INSERT INTO countries (iso_alpha2, iso_alpha3, name) VALUES
     ('ZA', 'ZAF', 'South Africa')
 ON CONFLICT (iso_alpha2) DO NOTHING;
 
-INSERT INTO recruitment_statuses (status_code, description) VALUES
+INSERT INTO vocabulary_recruitment_status (code, description) VALUES
     ('NOT_YET_RECRUITING', 'Trial has been registered but enrollment has not yet begun.'),
     ('RECRUITING', 'Actively recruiting participants.'),
     ('ACTIVE_NOT_RECRUITING', 'Active, but not currently recruiting participants.'),
     ('COMPLETED', 'Study has reached overall completion and data collection has ended.'),
     ('TERMINATED', 'Study has stopped early and will not start again.')
-ON CONFLICT (status_code) DO NOTHING;
+ON CONFLICT (code) DO NOTHING;
 
-INSERT INTO intervention_types (type_code, description) VALUES
+INSERT INTO vocabulary_intervention_type (code, description) VALUES
     ('DRUG', 'Pharmaceutical or biological drug interventions.'),
     ('DEVICE', 'Medical device interventions.'),
     ('PROCEDURE', 'Surgical or procedural interventions.'),
     ('BEHAVIORAL', 'Behavioral, lifestyle, or educational interventions.'),
     ('DIETARY_SUPPLEMENT', 'Vitamins, minerals, and dietary supplements.')
-ON CONFLICT (type_code) DO NOTHING;
+ON CONFLICT (code) DO NOTHING;
 
-INSERT INTO study_phases (phase_code, description) VALUES
+INSERT INTO vocabulary_study_phase (code, description) VALUES
     ('EARLY_PHASE1', 'Early Phase 1 (formerly Phase 0).'),
     ('PHASE1', 'Phase 1 safety trials.'),
     ('PHASE2', 'Phase 2 efficacy and side effects trials.'),
     ('PHASE3', 'Phase 3 effectiveness trials.'),
     ('PHASE4', 'Phase 4 post-marketing studies.')
-ON CONFLICT (phase_code) DO NOTHING;
+ON CONFLICT (code) DO NOTHING;
 
-INSERT INTO condition_categories (category_code, name, description) VALUES
+INSERT INTO vocabulary_condition_category (code, name, description) VALUES
     ('ONCOLOGY', 'Oncology', 'Cancer-related conditions.'),
     ('CARDIO', 'Cardiology', 'Cardiovascular system disorders.'),
     ('NEURO', 'Neurology', 'Brain and nervous system conditions.'),
     ('INFECT', 'Infectious Disease', 'Viral and bacterial infections.'),
     ('ENDO', 'Endocrinology', 'Hormonal and metabolic disorders.')
-ON CONFLICT (category_code) DO NOTHING;
+ON CONFLICT (code) DO NOTHING;
 

--- a/database/sql/vocabulary_tables.sql
+++ b/database/sql/vocabulary_tables.sql
@@ -1,34 +1,34 @@
--- Vocabulary tables for clinical trial administration
--- These tables hold controlled vocabularies referenced by the core schema.
+-- Vocabulary tables for clinical trial administration (ct schema)
+-- Updated naming aligns with new ct dump conventions.
 
-CREATE TABLE IF NOT EXISTS countries (
-    country_id SERIAL PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS vocabulary_country (
+    id SERIAL PRIMARY KEY,
     iso_alpha2 CHAR(2) NOT NULL UNIQUE,
     iso_alpha3 CHAR(3) NOT NULL UNIQUE,
     name TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS recruitment_statuses (
-    recruitment_status_id SERIAL PRIMARY KEY,
-    status_code TEXT NOT NULL UNIQUE,
+CREATE TABLE IF NOT EXISTS vocabulary_recruitment_status (
+    id SERIAL PRIMARY KEY,
+    code TEXT NOT NULL UNIQUE,
     description TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS intervention_types (
-    intervention_type_id SERIAL PRIMARY KEY,
-    type_code TEXT NOT NULL UNIQUE,
+CREATE TABLE IF NOT EXISTS vocabulary_intervention_type (
+    id SERIAL PRIMARY KEY,
+    code TEXT NOT NULL UNIQUE,
     description TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS study_phases (
-    study_phase_id SERIAL PRIMARY KEY,
-    phase_code TEXT NOT NULL UNIQUE,
+CREATE TABLE IF NOT EXISTS vocabulary_study_phase (
+    id SERIAL PRIMARY KEY,
+    code TEXT NOT NULL UNIQUE,
     description TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS condition_categories (
-    condition_category_id SERIAL PRIMARY KEY,
-    category_code TEXT NOT NULL UNIQUE,
+CREATE TABLE IF NOT EXISTS vocabulary_condition_category (
+    id SERIAL PRIMARY KEY,
+    code TEXT NOT NULL UNIQUE,
     name TEXT NOT NULL,
     description TEXT
 );

--- a/database/stored_procedures/create_trial.sql
+++ b/database/stored_procedures/create_trial.sql
@@ -6,7 +6,8 @@ CREATE OR REPLACE PROCEDURE create_trial(
     p_brief_summary TEXT DEFAULT NULL,
     p_lead_sponsor_name TEXT DEFAULT NULL,
     p_lead_sponsor_type TEXT DEFAULT NULL,
-    p_lead_sponsor_email TEXT DEFAULT NULL
+    p_lead_sponsor_email TEXT DEFAULT NULL,
+    p_responsible_institution_id INTEGER DEFAULT NULL
 )
 LANGUAGE plpgsql
 AS $$
@@ -15,18 +16,18 @@ DECLARE
     v_study_phase_id INTEGER;
     v_lead_sponsor_id INTEGER;
 BEGIN
-    SELECT recruitment_status_id INTO v_recruitment_status_id
-    FROM recruitment_statuses
-    WHERE status_code = p_recruitment_status_code;
+    SELECT id INTO v_recruitment_status_id
+    FROM vocabulary_recruitment_status
+    WHERE code = p_recruitment_status_code;
 
     IF v_recruitment_status_id IS NULL THEN
         RAISE EXCEPTION 'Unknown recruitment status code: %', p_recruitment_status_code;
     END IF;
 
     IF p_study_phase_code IS NOT NULL THEN
-        SELECT study_phase_id INTO v_study_phase_id
-        FROM study_phases
-        WHERE phase_code = p_study_phase_code;
+        SELECT id INTO v_study_phase_id
+        FROM vocabulary_study_phase
+        WHERE code = p_study_phase_code;
 
         IF v_study_phase_id IS NULL THEN
             RAISE EXCEPTION 'Unknown study phase code: %', p_study_phase_code;
@@ -41,7 +42,8 @@ BEGIN
         recruitment_status_id,
         study_phase_id,
         brief_summary,
-        lead_sponsor_id
+        lead_sponsor_id,
+        responsible_institution_id
     )
     VALUES (
         p_public_identifier,
@@ -49,7 +51,8 @@ BEGIN
         v_recruitment_status_id,
         v_study_phase_id,
         p_brief_summary,
-        v_lead_sponsor_id
+        v_lead_sponsor_id,
+        p_responsible_institution_id
     );
 END;
 $$;

--- a/database/stored_procedures/list_trials.sql
+++ b/database/stored_procedures/list_trials.sql
@@ -8,15 +8,15 @@ AS $$
         'official_title', t.official_title,
         'brief_summary', t.brief_summary,
         'recruitment_status', jsonb_build_object(
-            'id', rs.recruitment_status_id,
-            'code', rs.status_code,
+            'id', rs.id,
+            'code', rs.code,
             'description', rs.description
         ),
         'study_phase', CASE
-            WHEN sp.study_phase_id IS NULL THEN NULL
+            WHEN sp.id IS NULL THEN NULL
             ELSE jsonb_build_object(
-                'id', sp.study_phase_id,
-                'code', sp.phase_code,
+                'id', sp.id,
+                'code', sp.code,
                 'description', sp.description
             )
         END,
@@ -31,6 +31,20 @@ AS $$
                 'contact_email', s.contact_email
             )
         END,
+        'responsible_institution', CASE
+            WHEN ri.research_institution_id IS NULL THEN NULL
+            ELSE jsonb_build_object(
+                'research_institution_id', ri.research_institution_id,
+                'name', ri.name,
+                'country', jsonb_build_object(
+                    'id', vc.id,
+                    'code', vc.iso_alpha2,
+                    'name', vc.name
+                ),
+                'city', ri.city,
+                'state_province', ri.state_province
+            )
+        END,
         'countries', COALESCE(country_data.countries, '[]'::jsonb),
         'interventions', COALESCE(intervention_data.interventions, '[]'::jsonb),
         'conditions', COALESCE(condition_data.conditions, '[]'::jsonb),
@@ -39,9 +53,11 @@ AS $$
         'updated_at', to_jsonb(t.updated_at)
     )
     FROM trials AS t
-    JOIN recruitment_statuses AS rs ON rs.recruitment_status_id = t.recruitment_status_id
-    LEFT JOIN study_phases AS sp ON sp.study_phase_id = t.study_phase_id
+    JOIN vocabulary_recruitment_status AS rs ON rs.id = t.recruitment_status_id
+    LEFT JOIN vocabulary_study_phase AS sp ON sp.id = t.study_phase_id
     LEFT JOIN sponsors AS s ON s.sponsor_id = t.lead_sponsor_id
+    LEFT JOIN research_institutions AS ri ON ri.research_institution_id = t.responsible_institution_id
+    LEFT JOIN vocabulary_country AS vc ON vc.id = ri.country_id
     LEFT JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
@@ -50,11 +66,12 @@ AS $$
                 'country_code', c.iso_alpha2,
                 'country_name', c.name,
                 'city', tc.city,
-                'site_name', tc.site_name
+                'site_name', tc.site_name,
+                'research_institution_id', tc.research_institution_id
             ) ORDER BY c.name, tc.city, tc.site_name
         ) AS countries
         FROM trial_countries AS tc
-        JOIN countries AS c ON c.country_id = tc.country_id
+        JOIN vocabulary_country AS c ON c.id = tc.country_id
         WHERE tc.trial_id = t.trial_id
     ) AS country_data ON TRUE
     LEFT JOIN LATERAL (
@@ -64,14 +81,14 @@ AS $$
                 'name', i.name,
                 'description', i.description,
                 'intervention_type', jsonb_build_object(
-                    'id', it.intervention_type_id,
-                    'code', it.type_code,
+                    'id', it.id,
+                    'code', it.code,
                     'description', it.description
                 )
             ) ORDER BY i.name
         ) AS interventions
         FROM interventions AS i
-        JOIN intervention_types AS it ON it.intervention_type_id = i.intervention_type_id
+        JOIN vocabulary_intervention_type AS it ON it.id = i.intervention_type_id
         WHERE i.trial_id = t.trial_id
     ) AS intervention_data ON TRUE
     LEFT JOIN LATERAL (
@@ -80,10 +97,10 @@ AS $$
                 'trial_condition_id', tc.trial_condition_id,
                 'condition_name', tc.condition_name,
                 'condition_category', CASE
-                    WHEN cc.condition_category_id IS NULL THEN NULL
+                    WHEN cc.id IS NULL THEN NULL
                     ELSE jsonb_build_object(
-                        'id', cc.condition_category_id,
-                        'code', cc.category_code,
+                        'id', cc.id,
+                        'code', cc.code,
                         'name', cc.name,
                         'description', cc.description
                     )
@@ -91,7 +108,7 @@ AS $$
             ) ORDER BY tc.condition_name
         ) AS conditions
         FROM trial_conditions AS tc
-        LEFT JOIN condition_categories AS cc ON cc.condition_category_id = tc.condition_category_id
+        LEFT JOIN vocabulary_condition_category AS cc ON cc.id = tc.condition_category_id
         WHERE tc.trial_id = t.trial_id
     ) AS condition_data ON TRUE
     LEFT JOIN LATERAL (


### PR DESCRIPTION
## Summary
- replace the core clinical_trial_tables.sql DDL with the provided ct dump, adding the research_institutions table, new sequences, and updated foreign keys and expression indexes
- rename the vocabulary tables and seeds to the vocabulary_* convention consumed by the ct schema
- update stored procedures, Django reference queries, and documentation to reference the new vocabulary naming and schema elements

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dbdeee7e6c8327bdea7d2d9af2ab67