### PR TITLE
Add register code generator function

### DIFF
--- a/database/sql/supporting_objects.sql
+++ b/database/sql/supporting_objects.sql
@@ -20,3 +20,35 @@ BEGIN
     END IF;
 END;
 $$;
+
+-- Function: generate_register_code(prefix VARCHAR(3))
+-- Author: Legacy CTMS Data Engineering Team
+
+CREATE OR REPLACE FUNCTION generate_register_code(prefix VARCHAR(3))
+RETURNS TEXT AS $$
+DECLARE
+    v_suffix INTEGER;
+    v_candidate TEXT;
+BEGIN
+    IF prefix IS NULL OR LENGTH(prefix) <> 3 THEN
+        RAISE EXCEPTION 'Prefix must be exactly three characters';
+    END IF;
+
+    SELECT COALESCE(MAX(SUBSTRING(register_id FROM 4)::INTEGER), 0) + 1
+    INTO v_suffix
+    FROM ct
+    WHERE register_id LIKE prefix || '%';
+
+    LOOP
+        v_candidate := prefix || TO_CHAR(v_suffix, 'FM0000000');
+        EXIT WHEN NOT EXISTS (
+            SELECT 1
+            FROM ct
+            WHERE register_id = v_candidate
+        );
+        v_suffix := v_suffix + 1;
+    END LOOP;
+
+    RETURN v_candidate;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- append the legacy generate_register_code helper function, including its comment header, to supporting_objects.sql
- keep supporting_objects.sql aligned with legacy triggers by checking for additional routines to port
- confirmed bootstrap order still creates supporting objects after the clinical trial tables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdeef8d2083279bb5bfb35bed39ca