### PR TITLE
Move institution unique constraint to index

### DIFF
--- a/database/sql/vocabulary_tables.sql
+++ b/database/sql/vocabulary_tables.sql
@@ -97,9 +97,11 @@ CREATE TABLE IF NOT EXISTS vocabulary_institution (
     website TEXT,
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT vocabulary_institution_unique UNIQUE (name, COALESCE(legal_name, ''))
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS vocabulary_institution_name_legal_name_uniq
+    ON vocabulary_institution (name, COALESCE(legal_name, ''));
 
 ALTER SEQUENCE vocabulary_institution_id_seq OWNED BY vocabulary_institution.id;
 


### PR DESCRIPTION
## Summary
- remove the inline unique constraint from the vocabulary_institution table definition
- add an equivalent unique index on name and legal_name using COALESCE

## Testing
- `python -m database.bootstrap` *(fails: Missing required environment variables for database connection: DB_NAME, DB_USER)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0588093083278b09d1ef2e5b9a5a