### PR TITLE
Refactor clinical trial DDL to ct schema

### DIFF
--- a/database/sql/clinical_trial_tables.sql
+++ b/database/sql/clinical_trial_tables.sql
@@ -1,5 +1,10 @@
--- Clinical trial schema extracted from ct schema dump
--- Recreates tables, sequences, defaults, primary keys, foreign keys, and indexes.
+-- Clinical trial schema reconstructed from consolidated ct dump
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+--
+-- This script recreates the PostgreSQL objects that compose the new
+-- clinical trial data model. It mirrors the structures extracted from
+-- the `ct` schema dump, preserving sequences, defaults, primary keys,
+-- foreign keys, indexes, and author comments.
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,377 +17,281 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: sponsors; Type: TABLE; Schema: public; Owner: -
---
+-- Core clinical trial registration table.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_id_seq;
 
-CREATE TABLE IF NOT EXISTS sponsors (
-    sponsor_id integer NOT NULL,
-    name text NOT NULL,
-    sponsor_type text,
-    contact_email text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_id_seq'),
+    register_id VARCHAR(15) NOT NULL,
+    protocol_number TEXT,
+    universal_trial_number TEXT,
+    public_title TEXT NOT NULL,
+    scientific_title TEXT,
+    acronym VARCHAR(50),
+    recruitment_status_id BIGINT NOT NULL REFERENCES vocabulary_recruitment_status(id),
+    study_phase_id BIGINT REFERENCES vocabulary_study_phase(id),
+    brief_summary TEXT,
+    detailed_description TEXT,
+    enrollment_target INTEGER,
+    enrollment_actual INTEGER,
+    enrollment_type TEXT,
+    study_start_date DATE,
+    primary_completion_date DATE,
+    completion_date DATE,
+    responsible_institution_id BIGINT REFERENCES vocabulary_institution(id),
+    primary_sponsor_id BIGINT REFERENCES vocabulary_institution(id),
+    study_sponsor_id BIGINT REFERENCES vocabulary_institution(id),
+    is_imported BOOLEAN NOT NULL DEFAULT FALSE,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_register_id_uniq UNIQUE (register_id)
 );
 
-CREATE SEQUENCE IF NOT EXISTS sponsors_sponsor_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_id_seq OWNED BY ct.id;
 
-ALTER SEQUENCE sponsors_sponsor_id_seq OWNED BY sponsors.sponsor_id;
+COMMENT ON TABLE ct IS 'Main registry record for a clinical trial as defined in the ct dump.';
+COMMENT ON COLUMN ct.register_id IS 'Unique registration identifier assigned by the platform.';
+COMMENT ON COLUMN ct.recruitment_status_id IS 'Links to vocabulary_recruitment_status.';
+COMMENT ON COLUMN ct.study_phase_id IS 'Links to vocabulary_study_phase.';
+COMMENT ON COLUMN ct.responsible_institution_id IS 'Institution responsible for conducting the trial.';
+COMMENT ON COLUMN ct.primary_sponsor_id IS 'Primary sponsor institution.';
+COMMENT ON COLUMN ct.study_sponsor_id IS 'Administrative sponsor or funding source.';
 
-ALTER TABLE ONLY sponsors ALTER COLUMN sponsor_id SET DEFAULT nextval('sponsors_sponsor_id_seq'::regclass);
+-- Secondary identifiers associated with a clinical trial.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_identifier_id_seq;
 
-ALTER TABLE ONLY sponsors
-    ADD CONSTRAINT sponsors_pkey PRIMARY KEY (sponsor_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS sponsors_name_lower_idx ON sponsors (lower(name));
-
---
--- Name: research_institutions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS research_institutions (
-    research_institution_id integer NOT NULL,
-    name text NOT NULL,
-    institution_type text,
-    country_id integer NOT NULL,
-    city text,
-    state_province text,
-    postal_code text,
-    contact_email text,
-    phone text,
-    is_active boolean DEFAULT true NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_identifier (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_identifier_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    identifier_type TEXT NOT NULL,
+    identifier_value TEXT NOT NULL,
+    issuing_authority TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_identifier_ct_id_identifier_value_uniq UNIQUE (ct_id, identifier_type, identifier_value)
 );
 
-CREATE SEQUENCE IF NOT EXISTS research_institutions_research_institution_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_identifier_id_seq OWNED BY ct_identifier.id;
 
-ALTER SEQUENCE research_institutions_research_institution_id_seq OWNED BY research_institutions.research_institution_id;
+COMMENT ON TABLE ct_identifier IS 'External identifiers (sponsor codes, registry numbers) for the clinical trial.';
 
-ALTER TABLE ONLY research_institutions
-    ALTER COLUMN research_institution_id SET DEFAULT nextval('research_institutions_research_institution_id_seq'::regclass);
+-- Institutions related to the trial and their roles.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_institution_id_seq;
 
-ALTER TABLE ONLY research_institutions
-    ADD CONSTRAINT research_institutions_pkey PRIMARY KEY (research_institution_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS research_institutions_name_country_idx
-    ON research_institutions (lower(name), country_id, COALESCE(lower(city), ''), COALESCE(lower(state_province), ''));
-
-ALTER TABLE ONLY research_institutions
-    ADD CONSTRAINT research_institutions_country_id_fkey FOREIGN KEY (country_id) REFERENCES vocabulary_country(id);
-
---
--- Name: trials; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trials (
-    trial_id integer NOT NULL,
-    public_identifier text NOT NULL,
-    official_title text NOT NULL,
-    brief_summary text,
-    recruitment_status_id integer NOT NULL,
-    study_phase_id integer,
-    lead_sponsor_id integer,
-    responsible_institution_id integer,
-    primary_completion_date date,
-    overall_completion_date date,
-    enrollment_actual integer,
-    enrollment_target integer,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_institution (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_institution_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    institution_id BIGINT NOT NULL REFERENCES vocabulary_institution(id),
+    role TEXT NOT NULL,
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_institution_role_chk CHECK (role <> '')
 );
 
-CREATE SEQUENCE IF NOT EXISTS trials_trial_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_institution_id_seq OWNED BY ct_institution.id;
 
-ALTER SEQUENCE trials_trial_id_seq OWNED BY trials.trial_id;
+COMMENT ON TABLE ct_institution IS 'Associates registered institutions to the clinical trial with a specific role.';
 
-ALTER TABLE ONLY trials ALTER COLUMN trial_id SET DEFAULT nextval('trials_trial_id_seq'::regclass);
+-- Contact information for the clinical trial.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_contact_id_seq;
 
-ALTER TABLE ONLY trials
-    ADD CONSTRAINT trials_pkey PRIMARY KEY (trial_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS trials_public_identifier_lower_idx ON trials (lower(public_identifier));
-
-ALTER TABLE ONLY trials
-    ADD CONSTRAINT trials_lead_sponsor_id_fkey FOREIGN KEY (lead_sponsor_id) REFERENCES sponsors(sponsor_id);
-
-ALTER TABLE ONLY trials
-    ADD CONSTRAINT trials_recruitment_status_id_fkey FOREIGN KEY (recruitment_status_id) REFERENCES vocabulary_recruitment_status(id);
-
-ALTER TABLE ONLY trials
-    ADD CONSTRAINT trials_responsible_institution_id_fkey FOREIGN KEY (responsible_institution_id) REFERENCES research_institutions(research_institution_id);
-
-ALTER TABLE ONLY trials
-    ADD CONSTRAINT trials_study_phase_id_fkey FOREIGN KEY (study_phase_id) REFERENCES vocabulary_study_phase(id);
-
---
--- Name: trial_countries; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_countries (
-    trial_country_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    country_id integer NOT NULL,
-    city text,
-    site_name text,
-    research_institution_id integer,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_contact (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_contact_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    contact_role TEXT NOT NULL,
+    person_name TEXT NOT NULL,
+    email TEXT,
+    phone TEXT,
+    institution_id BIGINT REFERENCES vocabulary_institution(id),
+    country_id BIGINT REFERENCES vocabulary_country(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_contact_role_chk CHECK (contact_role <> '')
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_countries_trial_country_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_contact_id_seq OWNED BY ct_contact.id;
 
-ALTER SEQUENCE trial_countries_trial_country_id_seq OWNED BY trial_countries.trial_country_id;
+COMMENT ON TABLE ct_contact IS 'Contact roster for the trial (scientific and public contacts).';
 
-ALTER TABLE ONLY trial_countries ALTER COLUMN trial_country_id SET DEFAULT nextval('trial_countries_trial_country_id_seq'::regclass);
+-- Reported conditions linked to the trial.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_condition_id_seq;
 
-ALTER TABLE ONLY trial_countries
-    ADD CONSTRAINT trial_countries_pkey PRIMARY KEY (trial_country_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS trial_countries_unique_idx
-    ON trial_countries (trial_id, country_id, COALESCE(lower(city), ''), COALESCE(lower(site_name), ''), COALESCE(research_institution_id, 0));
-
-ALTER TABLE ONLY trial_countries
-    ADD CONSTRAINT trial_countries_country_id_fkey FOREIGN KEY (country_id) REFERENCES vocabulary_country(id);
-
-ALTER TABLE ONLY trial_countries
-    ADD CONSTRAINT trial_countries_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY trial_countries
-    ADD CONSTRAINT trial_countries_research_institution_id_fkey FOREIGN KEY (research_institution_id) REFERENCES research_institutions(research_institution_id) ON DELETE SET NULL;
-
---
--- Name: interventions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS interventions (
-    intervention_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    intervention_type_id integer NOT NULL,
-    name text NOT NULL,
-    description text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_condition (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_condition_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    condition_name TEXT NOT NULL,
+    condition_category_id BIGINT REFERENCES vocabulary_condition_category(id),
+    mesh_term TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE SEQUENCE IF NOT EXISTS interventions_intervention_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_condition_id_seq OWNED BY ct_condition.id;
 
-ALTER SEQUENCE interventions_intervention_id_seq OWNED BY interventions.intervention_id;
+COMMENT ON TABLE ct_condition IS 'Diseases or health conditions targeted by the clinical trial.';
 
-ALTER TABLE ONLY interventions ALTER COLUMN intervention_id SET DEFAULT nextval('interventions_intervention_id_seq'::regclass);
+-- Declared keywords supporting free-text search.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_keyword_id_seq;
 
-ALTER TABLE ONLY interventions
-    ADD CONSTRAINT interventions_pkey PRIMARY KEY (intervention_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS interventions_trial_id_name_key
-    ON interventions (trial_id, lower(name));
-
-ALTER TABLE ONLY interventions
-    ADD CONSTRAINT interventions_intervention_type_id_fkey FOREIGN KEY (intervention_type_id) REFERENCES vocabulary_intervention_type(id);
-
-ALTER TABLE ONLY interventions
-    ADD CONSTRAINT interventions_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
---
--- Name: trial_conditions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_conditions (
-    trial_condition_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    condition_category_id integer,
-    condition_name text NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_keyword (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_keyword_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    keyword TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_keyword_keyword_chk CHECK (keyword <> '')
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_conditions_trial_condition_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_keyword_id_seq OWNED BY ct_keyword.id;
 
-ALTER SEQUENCE trial_conditions_trial_condition_id_seq OWNED BY trial_conditions.trial_condition_id;
+COMMENT ON TABLE ct_keyword IS 'Search keywords supplied by the registrant.';
 
-ALTER TABLE ONLY trial_conditions ALTER COLUMN trial_condition_id SET DEFAULT nextval('trial_conditions_trial_condition_id_seq'::regclass);
+-- Study interventions.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_intervention_id_seq;
 
-ALTER TABLE ONLY trial_conditions
-    ADD CONSTRAINT trial_conditions_pkey PRIMARY KEY (trial_condition_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS trial_conditions_trial_id_condition_name_key
-    ON trial_conditions (trial_id, lower(condition_name));
-
-ALTER TABLE ONLY trial_conditions
-    ADD CONSTRAINT trial_conditions_condition_category_id_fkey FOREIGN KEY (condition_category_id) REFERENCES vocabulary_condition_category(id);
-
-ALTER TABLE ONLY trial_conditions
-    ADD CONSTRAINT trial_conditions_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
---
--- Name: trial_documents; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_documents (
-    trial_document_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    document_type text NOT NULL,
-    document_url text NOT NULL,
-    is_confidential boolean DEFAULT false NOT NULL,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_intervention (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_intervention_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    intervention_type_id BIGINT REFERENCES vocabulary_intervention_type(id),
+    intervention_category_id BIGINT REFERENCES vocabulary_intervention_category(id),
+    name TEXT NOT NULL,
+    description TEXT,
+    other_names TEXT,
+    arm_group TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_documents_trial_document_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_intervention_id_seq OWNED BY ct_intervention.id;
 
-ALTER SEQUENCE trial_documents_trial_document_id_seq OWNED BY trial_documents.trial_document_id;
+COMMENT ON TABLE ct_intervention IS 'Interventions evaluated in the clinical trial.';
 
-ALTER TABLE ONLY trial_documents ALTER COLUMN trial_document_id SET DEFAULT nextval('trial_documents_trial_document_id_seq'::regclass);
+-- Outcome measures declared by the investigators.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_outcome_id_seq;
 
-ALTER TABLE ONLY trial_documents
-    ADD CONSTRAINT trial_documents_pkey PRIMARY KEY (trial_document_id);
-
-ALTER TABLE ONLY trial_documents
-    ADD CONSTRAINT trial_documents_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
---
--- Name: trial_contacts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_contacts (
-    trial_contact_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    contact_type text NOT NULL,
-    given_name text,
-    family_name text,
-    email text,
-    phone text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_outcome (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_outcome_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    outcome_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    time_frame TEXT,
+    is_safety_issue BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ct_outcome_type_chk CHECK (outcome_type IN ('PRIMARY', 'SECONDARY', 'OTHER'))
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_contacts_trial_contact_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_outcome_id_seq OWNED BY ct_outcome.id;
 
-ALTER SEQUENCE trial_contacts_trial_contact_id_seq OWNED BY trial_contacts.trial_contact_id;
+COMMENT ON TABLE ct_outcome IS 'Primary and secondary outcome measures for the clinical trial.';
 
-ALTER TABLE ONLY trial_contacts ALTER COLUMN trial_contact_id SET DEFAULT nextval('trial_contacts_trial_contact_id_seq'::regclass);
+-- Recruitment locations and facilities.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_location_id_seq;
 
-ALTER TABLE ONLY trial_contacts
-    ADD CONSTRAINT trial_contacts_pkey PRIMARY KEY (trial_contact_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS trial_contacts_unique_idx
-    ON trial_contacts (trial_id, lower(COALESCE(email, '')), lower(COALESCE(phone, '')), contact_type);
-
-ALTER TABLE ONLY trial_contacts
-    ADD CONSTRAINT trial_contacts_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
---
--- Name: trial_status_history; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_status_history (
-    trial_status_history_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    recruitment_status_id integer NOT NULL,
-    status_date date NOT NULL,
-    note text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_location (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_location_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    country_id BIGINT NOT NULL REFERENCES vocabulary_country(id),
+    state TEXT,
+    city TEXT,
+    institution_id BIGINT REFERENCES vocabulary_institution(id),
+    postal_code TEXT,
+    status TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_status_history_trial_status_history_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_location_id_seq OWNED BY ct_location.id;
 
-ALTER SEQUENCE trial_status_history_trial_status_history_id_seq OWNED BY trial_status_history.trial_status_history_id;
+COMMENT ON TABLE ct_location IS 'Geographic locations where the trial recruits participants.';
 
-ALTER TABLE ONLY trial_status_history ALTER COLUMN trial_status_history_id SET DEFAULT nextval('trial_status_history_trial_status_history_id_seq'::regclass);
+-- Documents uploaded or referenced by the registrant.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_document_id_seq;
 
-ALTER TABLE ONLY trial_status_history
-    ADD CONSTRAINT trial_status_history_pkey PRIMARY KEY (trial_status_history_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS trial_status_history_unique_idx
-    ON trial_status_history (trial_id, recruitment_status_id, status_date);
-
-ALTER TABLE ONLY trial_status_history
-    ADD CONSTRAINT trial_status_history_recruitment_status_id_fkey FOREIGN KEY (recruitment_status_id) REFERENCES vocabulary_recruitment_status(id);
-
-ALTER TABLE ONLY trial_status_history
-    ADD CONSTRAINT trial_status_history_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
-
---
--- Name: trial_identifiers; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS trial_identifiers (
-    trial_identifier_id integer NOT NULL,
-    trial_id integer NOT NULL,
-    identifier_type text NOT NULL,
-    identifier_value text NOT NULL,
-    issued_by text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+CREATE TABLE IF NOT EXISTS ct_document (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_document_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    document_type TEXT NOT NULL,
+    description TEXT,
+    url TEXT,
+    file_name TEXT,
+    version TEXT,
+    uploaded_at TIMESTAMPTZ DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE SEQUENCE IF NOT EXISTS trial_identifiers_trial_identifier_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
+ALTER SEQUENCE ct_document_id_seq OWNED BY ct_document.id;
 
-ALTER SEQUENCE trial_identifiers_trial_identifier_id_seq OWNED BY trial_identifiers.trial_identifier_id;
+COMMENT ON TABLE ct_document IS 'Registry documents (protocols, consent forms, approvals).';
 
-ALTER TABLE ONLY trial_identifiers ALTER COLUMN trial_identifier_id SET DEFAULT nextval('trial_identifiers_trial_identifier_id_seq'::regclass);
+-- Ethics committee approvals linked to the trial.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_ethics_approval_id_seq;
 
-ALTER TABLE ONLY trial_identifiers
-    ADD CONSTRAINT trial_identifiers_pkey PRIMARY KEY (trial_identifier_id);
+CREATE TABLE IF NOT EXISTS ct_ethics_approval (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_ethics_approval_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    committee_name TEXT NOT NULL,
+    approval_number TEXT,
+    approval_date DATE,
+    institution_id BIGINT REFERENCES vocabulary_institution(id),
+    country_id BIGINT REFERENCES vocabulary_country(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
 
-CREATE UNIQUE INDEX IF NOT EXISTS trial_identifiers_unique_idx
-    ON trial_identifiers (trial_id, lower(identifier_type), lower(identifier_value));
+ALTER SEQUENCE ct_ethics_approval_id_seq OWNED BY ct_ethics_approval.id;
 
-ALTER TABLE ONLY trial_identifiers
-    ADD CONSTRAINT trial_identifiers_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(trial_id) ON DELETE CASCADE;
+COMMENT ON TABLE ct_ethics_approval IS 'Institutional review board approvals associated with the trial.';
+
+-- Recruitment milestones to trace historical changes.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_status_history_id_seq;
+
+CREATE TABLE IF NOT EXISTS ct_status_history (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_status_history_id_seq'),
+    ct_id BIGINT NOT NULL REFERENCES ct(id) ON DELETE CASCADE,
+    recruitment_status_id BIGINT NOT NULL REFERENCES vocabulary_recruitment_status(id),
+    status_date DATE NOT NULL,
+    comment TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER SEQUENCE ct_status_history_id_seq OWNED BY ct_status_history.id;
+
+COMMENT ON TABLE ct_status_history IS 'Historical log of recruitment status transitions for the trial.';
+
+-- Auditing table capturing raw import metadata.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/>
+CREATE SEQUENCE IF NOT EXISTS ct_import_log_id_seq;
+
+CREATE TABLE IF NOT EXISTS ct_import_log (
+    id BIGINT PRIMARY KEY DEFAULT nextval('ct_import_log_id_seq'),
+    ct_id BIGINT REFERENCES ct(id) ON DELETE SET NULL,
+    source_system TEXT NOT NULL,
+    source_identifier TEXT,
+    payload JSONB,
+    imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER SEQUENCE ct_import_log_id_seq OWNED BY ct_import_log.id;
+
+COMMENT ON TABLE ct_import_log IS 'Stores metadata about imported records from external registries.';
 

--- a/database/sql/supporting_objects.sql
+++ b/database/sql/supporting_objects.sql
@@ -11,10 +11,10 @@ $$ LANGUAGE plpgsql;
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_trigger WHERE tgname = 'trials_set_updated_at'
+        SELECT 1 FROM pg_trigger WHERE tgname = 'ct_set_updated_at'
     ) THEN
-        CREATE TRIGGER trials_set_updated_at
-        BEFORE UPDATE ON trials
+        CREATE TRIGGER ct_set_updated_at
+        BEFORE UPDATE ON ct
         FOR EACH ROW
         EXECUTE FUNCTION set_updated_at();
     END IF;

--- a/database/stored_procedures/create_trial.sql
+++ b/database/stored_procedures/create_trial.sql
@@ -1,20 +1,20 @@
 CREATE OR REPLACE PROCEDURE create_trial(
-    p_public_identifier TEXT,
-    p_official_title TEXT,
+    p_register_id TEXT,
+    p_public_title TEXT,
     p_recruitment_status_code TEXT,
     p_study_phase_code TEXT DEFAULT NULL,
     p_brief_summary TEXT DEFAULT NULL,
-    p_lead_sponsor_name TEXT DEFAULT NULL,
-    p_lead_sponsor_type TEXT DEFAULT NULL,
-    p_lead_sponsor_email TEXT DEFAULT NULL,
-    p_responsible_institution_id INTEGER DEFAULT NULL
+    p_primary_sponsor_name TEXT DEFAULT NULL,
+    p_primary_sponsor_type TEXT DEFAULT NULL,
+    p_primary_sponsor_email TEXT DEFAULT NULL,
+    p_responsible_institution_id BIGINT DEFAULT NULL
 )
 LANGUAGE plpgsql
 AS $$
 DECLARE
-    v_recruitment_status_id INTEGER;
-    v_study_phase_id INTEGER;
-    v_lead_sponsor_id INTEGER;
+    v_recruitment_status_id BIGINT;
+    v_study_phase_id BIGINT;
+    v_primary_sponsor_id BIGINT;
 BEGIN
     SELECT id INTO v_recruitment_status_id
     FROM vocabulary_recruitment_status
@@ -34,24 +34,26 @@ BEGIN
         END IF;
     END IF;
 
-    v_lead_sponsor_id := get_or_create_sponsor(p_lead_sponsor_name, p_lead_sponsor_type, p_lead_sponsor_email);
+    v_primary_sponsor_id := get_or_create_sponsor(p_primary_sponsor_name, p_primary_sponsor_type, p_primary_sponsor_email);
 
-    INSERT INTO trials (
-        public_identifier,
-        official_title,
+    INSERT INTO ct (
+        register_id,
+        public_title,
+        scientific_title,
         recruitment_status_id,
         study_phase_id,
         brief_summary,
-        lead_sponsor_id,
+        primary_sponsor_id,
         responsible_institution_id
     )
     VALUES (
-        p_public_identifier,
-        p_official_title,
+        p_register_id,
+        p_public_title,
+        p_public_title,
         v_recruitment_status_id,
         v_study_phase_id,
         p_brief_summary,
-        v_lead_sponsor_id,
+        v_primary_sponsor_id,
         p_responsible_institution_id
     );
 END;

--- a/database/stored_procedures/get_or_create_sponsor.sql
+++ b/database/stored_procedures/get_or_create_sponsor.sql
@@ -1,20 +1,25 @@
 CREATE OR REPLACE FUNCTION get_or_create_sponsor(p_name TEXT, p_type TEXT, p_email TEXT)
-RETURNS INTEGER AS $$
+RETURNS BIGINT AS $$
 DECLARE
-    v_id INTEGER;
+    v_id BIGINT;
 BEGIN
-    IF p_name IS NULL THEN
+    IF p_name IS NULL OR btrim(p_name) = '' THEN
         RETURN NULL;
     END IF;
 
-    SELECT sponsor_id INTO v_id
-    FROM sponsors
+    SELECT id INTO v_id
+    FROM vocabulary_institution
     WHERE name = p_name;
 
     IF v_id IS NULL THEN
-        INSERT INTO sponsors(name, sponsor_type, contact_email)
-        VALUES (p_name, p_type, p_email)
-        RETURNING sponsor_id INTO v_id;
+        INSERT INTO vocabulary_institution(name, email)
+        VALUES (p_name, p_email)
+        RETURNING id INTO v_id;
+    ELSE
+        UPDATE vocabulary_institution
+        SET email = COALESCE(p_email, email),
+            updated_at = NOW()
+        WHERE id = v_id;
     END IF;
 
     RETURN v_id;

--- a/database/stored_procedures/list_trials.sql
+++ b/database/stored_procedures/list_trials.sql
@@ -3,10 +3,11 @@ RETURNS SETOF jsonb
 LANGUAGE sql
 AS $$
     SELECT jsonb_build_object(
-        'trial_id', t.trial_id,
-        'public_identifier', t.public_identifier,
-        'official_title', t.official_title,
-        'brief_summary', t.brief_summary,
+        'ct_id', c.id,
+        'register_id', c.register_id,
+        'public_title', c.public_title,
+        'scientific_title', c.scientific_title,
+        'brief_summary', c.brief_summary,
         'recruitment_status', jsonb_build_object(
             'id', rs.id,
             'code', rs.code,
@@ -20,109 +21,131 @@ AS $$
                 'description', sp.description
             )
         END,
-        'primary_completion_date', to_jsonb(t.primary_completion_date),
-        'overall_completion_date', to_jsonb(t.overall_completion_date),
-        'lead_sponsor', CASE
-            WHEN s.sponsor_id IS NULL THEN NULL
+        'primary_sponsor', CASE
+            WHEN ps.id IS NULL THEN NULL
             ELSE jsonb_build_object(
-                'sponsor_id', s.sponsor_id,
-                'name', s.name,
-                'sponsor_type', s.sponsor_type,
-                'contact_email', s.contact_email
+                'id', ps.id,
+                'name', ps.name,
+                'email', ps.email,
+                'country_id', ps.country_id
             )
         END,
         'responsible_institution', CASE
-            WHEN ri.research_institution_id IS NULL THEN NULL
+            WHEN ri.id IS NULL THEN NULL
             ELSE jsonb_build_object(
-                'research_institution_id', ri.research_institution_id,
+                'id', ri.id,
                 'name', ri.name,
-                'country', jsonb_build_object(
-                    'id', vc.id,
-                    'code', vc.iso_alpha2,
-                    'name', vc.name
-                ),
-                'city', ri.city,
-                'state_province', ri.state_province
+                'country', CASE
+                    WHEN ric.id IS NULL THEN NULL
+                    ELSE jsonb_build_object(
+                        'id', ric.id,
+                        'code', ric.iso_alpha2,
+                        'name', ric.name
+                    )
+                END
             )
         END,
-        'countries', COALESCE(country_data.countries, '[]'::jsonb),
+        'locations', COALESCE(location_data.locations, '[]'::jsonb),
         'interventions', COALESCE(intervention_data.interventions, '[]'::jsonb),
         'conditions', COALESCE(condition_data.conditions, '[]'::jsonb),
         'documents', COALESCE(document_data.documents, '[]'::jsonb),
-        'created_at', to_jsonb(t.created_at),
-        'updated_at', to_jsonb(t.updated_at)
+        'created_at', to_jsonb(c.created_at),
+        'updated_at', to_jsonb(c.updated_at)
     )
-    FROM trials AS t
-    JOIN vocabulary_recruitment_status AS rs ON rs.id = t.recruitment_status_id
-    LEFT JOIN vocabulary_study_phase AS sp ON sp.id = t.study_phase_id
-    LEFT JOIN sponsors AS s ON s.sponsor_id = t.lead_sponsor_id
-    LEFT JOIN research_institutions AS ri ON ri.research_institution_id = t.responsible_institution_id
-    LEFT JOIN vocabulary_country AS vc ON vc.id = ri.country_id
+    FROM ct AS c
+    JOIN vocabulary_recruitment_status AS rs ON rs.id = c.recruitment_status_id
+    LEFT JOIN vocabulary_study_phase AS sp ON sp.id = c.study_phase_id
+    LEFT JOIN vocabulary_institution AS ps ON ps.id = c.primary_sponsor_id
+    LEFT JOIN vocabulary_institution AS ri ON ri.id = c.responsible_institution_id
+    LEFT JOIN vocabulary_country AS ric ON ric.id = ri.country_id
     LEFT JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
-                'trial_country_id', tc.trial_country_id,
-                'country_id', tc.country_id,
-                'country_code', c.iso_alpha2,
-                'country_name', c.name,
-                'city', tc.city,
-                'site_name', tc.site_name,
-                'research_institution_id', tc.research_institution_id
-            ) ORDER BY c.name, tc.city, tc.site_name
-        ) AS countries
-        FROM trial_countries AS tc
-        JOIN vocabulary_country AS c ON c.id = tc.country_id
-        WHERE tc.trial_id = t.trial_id
-    ) AS country_data ON TRUE
+                'ct_location_id', cl.id,
+                'country', jsonb_build_object(
+                    'id', loc_country.id,
+                    'code', loc_country.iso_alpha2,
+                    'name', loc_country.name
+                ),
+                'state', cl.state,
+                'city', cl.city,
+                'institution', CASE
+                    WHEN loc_inst.id IS NULL THEN NULL
+                    ELSE jsonb_build_object(
+                        'id', loc_inst.id,
+                        'name', loc_inst.name
+                    )
+                END,
+                'postal_code', cl.postal_code,
+                'status', cl.status
+            ) ORDER BY loc_country.name, cl.state, cl.city
+        ) AS locations
+        FROM ct_location AS cl
+        JOIN vocabulary_country AS loc_country ON loc_country.id = cl.country_id
+        LEFT JOIN vocabulary_institution AS loc_inst ON loc_inst.id = cl.institution_id
+        WHERE cl.ct_id = c.id
+    ) AS location_data ON TRUE
     LEFT JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
-                'intervention_id', i.intervention_id,
-                'name', i.name,
-                'description', i.description,
-                'intervention_type', jsonb_build_object(
-                    'id', it.id,
-                    'code', it.code,
-                    'description', it.description
-                )
-            ) ORDER BY i.name
+                'ct_intervention_id', ci.id,
+                'name', ci.name,
+                'description', ci.description,
+                'intervention_type', CASE
+                    WHEN it.id IS NULL THEN NULL
+                    ELSE jsonb_build_object(
+                        'id', it.id,
+                        'code', it.code,
+                        'description', it.description
+                    )
+                END,
+                'intervention_category', CASE
+                    WHEN icat.id IS NULL THEN NULL
+                    ELSE jsonb_build_object(
+                        'id', icat.id,
+                        'code', icat.code,
+                        'description', icat.description
+                    )
+                END
+            ) ORDER BY ci.name
         ) AS interventions
-        FROM interventions AS i
-        JOIN vocabulary_intervention_type AS it ON it.id = i.intervention_type_id
-        WHERE i.trial_id = t.trial_id
+        FROM ct_intervention AS ci
+        LEFT JOIN vocabulary_intervention_type AS it ON it.id = ci.intervention_type_id
+        LEFT JOIN vocabulary_intervention_category AS icat ON icat.id = ci.intervention_category_id
+        WHERE ci.ct_id = c.id
     ) AS intervention_data ON TRUE
     LEFT JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
-                'trial_condition_id', tc.trial_condition_id,
-                'condition_name', tc.condition_name,
+                'ct_condition_id', cc.id,
+                'condition_name', cc.condition_name,
                 'condition_category', CASE
-                    WHEN cc.id IS NULL THEN NULL
+                    WHEN cat.id IS NULL THEN NULL
                     ELSE jsonb_build_object(
-                        'id', cc.id,
-                        'code', cc.code,
-                        'name', cc.name,
-                        'description', cc.description
+                        'id', cat.id,
+                        'code', cat.code,
+                        'name', cat.name,
+                        'description', cat.description
                     )
                 END
-            ) ORDER BY tc.condition_name
+            ) ORDER BY cc.condition_name
         ) AS conditions
-        FROM trial_conditions AS tc
-        LEFT JOIN vocabulary_condition_category AS cc ON cc.id = tc.condition_category_id
-        WHERE tc.trial_id = t.trial_id
+        FROM ct_condition AS cc
+        LEFT JOIN vocabulary_condition_category AS cat ON cat.id = cc.condition_category_id
+        WHERE cc.ct_id = c.id
     ) AS condition_data ON TRUE
     LEFT JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
-                'trial_document_id', td.trial_document_id,
-                'document_type', td.document_type,
-                'document_url', td.document_url,
-                'is_confidential', td.is_confidential,
-                'created_at', to_jsonb(td.created_at)
-            ) ORDER BY td.created_at, td.trial_document_id
+                'ct_document_id', cd.id,
+                'document_type', cd.document_type,
+                'url', cd.url,
+                'file_name', cd.file_name,
+                'uploaded_at', to_jsonb(cd.uploaded_at)
+            ) ORDER BY cd.uploaded_at, cd.id
         ) AS documents
-        FROM trial_documents AS td
-        WHERE td.trial_id = t.trial_id
+        FROM ct_document AS cd
+        WHERE cd.ct_id = c.id
     ) AS document_data ON TRUE
-    ORDER BY t.trial_id;
+    ORDER BY c.id;
 $$;


### PR DESCRIPTION
## Summary
- replace the clinical_trial_tables script with the ct-based schema, sequences, constraints, and comments from the consolidated dump
- adjust supporting triggers and helper functions to target the new ct relations
- update stored procedures to insert, resolve sponsors, and list trials against the ct schema

## Testing
- python -m database.bootstrap *(fails: missing required database environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0ae68c64832785ecc1198c1cb21d