### PR TITLE
Expand vocabulary schema with intervention tables

### DIFF
--- a/database/sql/vocabulary_seed.sql
+++ b/database/sql/vocabulary_seed.sql
@@ -8,20 +8,60 @@ INSERT INTO vocabulary_country (iso_alpha2, iso_alpha3, name) VALUES
     ('ZA', 'ZAF', 'South Africa')
 ON CONFLICT (iso_alpha2) DO NOTHING;
 
+INSERT INTO vocabulary_intervention_category (code, name, description) VALUES
+    ('MEDICINAL_PRODUCT', 'Medicinal Product', 'Drug, biologic, or vaccine based interventions.'),
+    ('MEDICAL_DEVICE', 'Medical Device', 'Devices, equipment, or diagnostic tools used in interventions.'),
+    ('NON_MEDICAL', 'Non-medical', 'Behavioral, dietary, educational, or procedural interventions.')
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO vocabulary_intervention_type (intervention_category_id, code, name, description)
+SELECT category.id, seed.code, seed.name, seed.description
+FROM (
+    VALUES
+        ('MEDICINAL_PRODUCT', 'DRUG', 'Drug', 'Pharmaceutical or biological drug interventions.'),
+        ('MEDICINAL_PRODUCT', 'BIOLOGIC', 'Biologic', 'Vaccines and other biologic interventions.'),
+        ('MEDICAL_DEVICE', 'DEVICE', 'Device', 'Medical device interventions.'),
+        ('NON_MEDICAL', 'PROCEDURE', 'Procedure', 'Surgical or procedural interventions.'),
+        ('NON_MEDICAL', 'BEHAVIORAL', 'Behavioral', 'Behavioral, lifestyle, or educational interventions.'),
+        ('NON_MEDICAL', 'DIETARY_SUPPLEMENT', 'Dietary Supplement', 'Vitamins, minerals, and dietary supplements.')
+) AS seed(category_code, code, name, description)
+JOIN vocabulary_intervention_category AS category ON category.code = seed.category_code
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO vocabulary_intervention_subtype (intervention_type_id, code, name, description)
+SELECT type.id, seed.code, seed.name, seed.description
+FROM (
+    VALUES
+        ('DRUG', 'SMALL_MOLECULE', 'Small Molecule', 'Chemically synthesised small molecule drug.'),
+        ('DRUG', 'BIOEQUIVALENCE', 'Bioequivalence', 'Studies comparing formulations of the same drug.'),
+        ('DEVICE', 'IMPLANTABLE', 'Implantable Device', 'Device implanted within the body.'),
+        ('BEHAVIORAL', 'COUNSELLING', 'Counselling', 'Structured behavioural counselling sessions.'),
+        ('DIETARY_SUPPLEMENT', 'VITAMIN', 'Vitamin Supplement', 'Vitamin-based dietary supplement.'),
+        ('PROCEDURE', 'SURGICAL', 'Surgical Procedure', 'Operative or invasive procedure.')
+) AS seed(type_code, code, name, description)
+JOIN vocabulary_intervention_type AS type ON type.code = seed.type_code
+ON CONFLICT (intervention_type_id, code) DO NOTHING;
+
+INSERT INTO vocabulary_intervention (intervention_type_id, intervention_subtype_id, code, name, description)
+SELECT type.id, subtype.id, seed.code, seed.name, seed.description
+FROM (
+    VALUES
+        ('DRUG', 'SMALL_MOLECULE', 'DRUG_PARACETAMOL', 'Paracetamol 500mg Tablet', 'Analgesic and antipyretic small molecule drug.'),
+        ('BIOLOGIC', NULL, 'BIO_VACCINE_MRNA', 'mRNA COVID-19 Vaccine', 'Messenger RNA vaccine targeting SARS-CoV-2.'),
+        ('DEVICE', 'IMPLANTABLE', 'DEV_PACEMAKER', 'Cardiac Pacemaker', 'Implantable cardiac rhythm management device.'),
+        ('BEHAVIORAL', 'COUNSELLING', 'BEH_CBT', 'Cognitive Behavioural Therapy', 'Structured CBT session programme.'),
+        ('DIETARY_SUPPLEMENT', 'VITAMIN', 'SUP_VITD', 'Vitamin D Supplement', 'Oral vitamin D3 supplement capsules.')
+) AS seed(type_code, subtype_code, code, name, description)
+JOIN vocabulary_intervention_type AS type ON type.code = seed.type_code
+LEFT JOIN vocabulary_intervention_subtype AS subtype ON subtype.code = seed.subtype_code AND subtype.intervention_type_id = type.id
+ON CONFLICT (code) DO NOTHING;
+
 INSERT INTO vocabulary_recruitment_status (code, description) VALUES
     ('NOT_YET_RECRUITING', 'Trial has been registered but enrollment has not yet begun.'),
     ('RECRUITING', 'Actively recruiting participants.'),
     ('ACTIVE_NOT_RECRUITING', 'Active, but not currently recruiting participants.'),
     ('COMPLETED', 'Study has reached overall completion and data collection has ended.'),
     ('TERMINATED', 'Study has stopped early and will not start again.')
-ON CONFLICT (code) DO NOTHING;
-
-INSERT INTO vocabulary_intervention_type (code, description) VALUES
-    ('DRUG', 'Pharmaceutical or biological drug interventions.'),
-    ('DEVICE', 'Medical device interventions.'),
-    ('PROCEDURE', 'Surgical or procedural interventions.'),
-    ('BEHAVIORAL', 'Behavioral, lifestyle, or educational interventions.'),
-    ('DIETARY_SUPPLEMENT', 'Vitamins, minerals, and dietary supplements.')
 ON CONFLICT (code) DO NOTHING;
 
 INSERT INTO vocabulary_study_phase (code, description) VALUES
@@ -38,5 +78,13 @@ INSERT INTO vocabulary_condition_category (code, name, description) VALUES
     ('NEURO', 'Neurology', 'Brain and nervous system conditions.'),
     ('INFECT', 'Infectious Disease', 'Viral and bacterial infections.'),
     ('ENDO', 'Endocrinology', 'Hormonal and metabolic disorders.')
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO vocabulary_secondary_identify_type (code, name, description) VALUES
+    ('EUCTR', 'EU Clinical Trials Register', 'Identifier issued by the EU Clinical Trials Register.'),
+    ('ISRCTN', 'ISRCTN Registry', 'Identifier assigned by the ISRCTN registry.'),
+    ('WHO', 'WHO Universal Trial Number', 'World Health Organization universal trial identifier.'),
+    ('ANVISA', 'ANVISA Register', 'Registration number assigned by ANVISA.'),
+    ('LOCAL', 'Local Registry', 'Identifier provided by a local or institutional registry.')
 ON CONFLICT (code) DO NOTHING;
 

--- a/database/sql/vocabulary_tables.sql
+++ b/database/sql/vocabulary_tables.sql
@@ -122,4 +122,126 @@ CREATE TABLE IF NOT EXISTS vocabulary_intervention_category (
 
 ALTER SEQUENCE vocabulary_intervention_category_id_seq OWNED BY vocabulary_intervention_category.id;
 
--- … (continua com intervention_type, subtype, study_phase etc. conforme `main`)
+-- Detailed classification for interventions grouped under broader categories.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_intervention_type_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_intervention_type (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_intervention_type_id_seq'),
+    intervention_category_id BIGINT REFERENCES vocabulary_intervention_category(id),
+    code VARCHAR(50) NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_intervention_type_code_uniq UNIQUE (code)
+);
+
+ALTER SEQUENCE vocabulary_intervention_type_id_seq OWNED BY vocabulary_intervention_type.id;
+
+-- Granular breakdown for intervention types capturing sub classifications.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_intervention_subtype_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_intervention_subtype (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_intervention_subtype_id_seq'),
+    intervention_type_id BIGINT NOT NULL REFERENCES vocabulary_intervention_type(id),
+    code VARCHAR(50) NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_intervention_subtype_type_code_uniq UNIQUE (intervention_type_id, code)
+);
+
+ALTER SEQUENCE vocabulary_intervention_subtype_id_seq OWNED BY vocabulary_intervention_subtype.id;
+
+-- Canonical registry of interventions harmonised across data sources.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_intervention_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_intervention (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_intervention_id_seq'),
+    intervention_type_id BIGINT REFERENCES vocabulary_intervention_type(id),
+    intervention_subtype_id BIGINT REFERENCES vocabulary_intervention_subtype(id),
+    code VARCHAR(100),
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_intervention_code_uniq UNIQUE (code)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS vocabulary_intervention_name_type_uniq
+    ON vocabulary_intervention (LOWER(name), COALESCE(intervention_type_id, 0));
+
+ALTER SEQUENCE vocabulary_intervention_id_seq OWNED BY vocabulary_intervention.id;
+
+-- Recruitment lifecycle statuses for registered clinical trials.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_recruitment_status_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_recruitment_status (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_recruitment_status_id_seq'),
+    code VARCHAR(50) NOT NULL,
+    description TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_recruitment_status_code_uniq UNIQUE (code)
+);
+
+ALTER SEQUENCE vocabulary_recruitment_status_id_seq OWNED BY vocabulary_recruitment_status.id;
+
+-- Study phases aligned with the harmonised clinical trial data model.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_study_phase_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_study_phase (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_study_phase_id_seq'),
+    code VARCHAR(50) NOT NULL,
+    description TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_study_phase_code_uniq UNIQUE (code)
+);
+
+ALTER SEQUENCE vocabulary_study_phase_id_seq OWNED BY vocabulary_study_phase.id;
+
+-- Controlled vocabulary grouping therapeutic condition categories.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_condition_category_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_condition_category (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_condition_category_id_seq'),
+    code VARCHAR(50) NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_condition_category_code_uniq UNIQUE (code)
+);
+
+ALTER SEQUENCE vocabulary_condition_category_id_seq OWNED BY vocabulary_condition_category.id;
+
+-- Secondary identifier types captured for harmonised registry references.
+-- Author: Diego Tostes – <https://www.linkedin.com/in/diegotostes/
+CREATE SEQUENCE IF NOT EXISTS vocabulary_secondary_identify_type_id_seq;
+
+CREATE TABLE IF NOT EXISTS vocabulary_secondary_identify_type (
+    id BIGINT PRIMARY KEY DEFAULT nextval('vocabulary_secondary_identify_type_id_seq'),
+    code VARCHAR(50) NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT vocabulary_secondary_identify_type_code_uniq UNIQUE (code)
+);
+
+ALTER SEQUENCE vocabulary_secondary_identify_type_id_seq OWNED BY vocabulary_secondary_identify_type.id;


### PR DESCRIPTION
## Summary
- add the remaining vocabulary tables from the dump, including intervention, recruitment status, study phase, condition category, and secondary identifier lookups
- create supporting sequences, constraints, and indexes for the new vocabulary tables to match the documented pattern
- seed the new vocabulary tables with the initial lookup values from the dump, keeping inserts idempotent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc0af56ab08327ac0456ae75c12e89